### PR TITLE
Resolve a cyclic dependency

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,6 @@ class python::config {
   Class['python::install'] -> Python::Virtualenv <| |>
 
   Python::Virtualenv <| |> -> Python::Pip <| |>
-  Python::Virtualenv <| |> -> Python::Requirements <| |>
 
   if $python::gunicorn {
     Class['python::install'] -> Python::Gunicorn <| |>

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -76,12 +76,17 @@ define python::virtualenv (
     }
 
     if $requirements {
-      Exec["python_virtualenv_${venv_dir}"]
-      -> Python::Requirements[$requirements]
+      exec { "python_requirements_initial_install_${requirements}":
+        command     => "${venv_dir}/bin/pip install ${proxy_flag} --requirement ${requirements}",
+        refreshonly => true,
+        timeout     => 1800,
+        subscribe   => Exec["python_virtualenv_${venv_dir}"],
+      }
 
       python::requirements { $requirements:
         virtualenv => $venv_dir,
         proxy      => $proxy,
+        require    => Exec["python_virtualenv_${venv_dir}"],
       }
     }
 


### PR DESCRIPTION
There was a dependency between python::virtualenv and
python::requirements. Basically, the virtualenv wanted to initialize
requirements, but requirements depended on the virtualenv being created
already, resulting in:

err: Could not apply complete catalog: Found 1 dependency cycle:
(Exec[python_requirements_check_/usr/share/err/repo/requirements.txt] =>
Python::Requirements[/usr/share/err/repo/requirements.txt] =>
Exec[python_virtualenv_/usr/share/err/python3] =>
Python::Requirements[/usr/share/err/repo/requirements.txt] =>
Exec[python_requirements_check_/usr/share/err/repo/requirements.txt])

This resolves that circular dependency and, as far as I can tell, does not negatively affect anything else.
