### PR TITLE
Add search path to virtualenv setup command.

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -82,6 +82,7 @@ define python::virtualenv (
         && virtualenv -p `which ${python}` ${system_pkgs_flag} ${venv_dir} \
         && ${venv_dir}/bin/pip install ${proxy_flag} --upgrade ${distribute_pkg} pip",
       creates => $venv_dir,
+      path    => [ '/bin', '/usr/bin', '/usr/sbin' ],
     }
 
     if $requirements {


### PR DESCRIPTION
Since i had trouble using the module together with vagrant i added explicit path declaration to the virtualenv definition.

The issue was that puppet seemed unable to locate the listed commands and suggested to specify absolute paths.
