### PR TITLE
Fix regression with $cwd in python::requirements

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -33,7 +33,7 @@ define python::requirements (
 
   $cwd = $virtualenv ? {
     'system' => '/',
-    default  => "${virtualenv}/bin/pip",
+    default  => "${virtualenv}/bin/",
   }
 
   $pip_env = $virtualenv ? {


### PR DESCRIPTION
Commit 8b22e3ecd90dd3ac741ff107d6f3fc8c511443ba introduces a regression which in some cases specifies the full path to pip as it's current working directory, rather than the actual directory pip is in. Obviously this will fail.

This commit fixes this.
