### PR TITLE
Removed Multiline backslashed from virtuelv Exec statement

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -86,10 +86,7 @@ define python::virtualenv (
 
 
     exec { "python_virtualenv_${venv_dir}":
-      command => "mkdir -p ${venv_dir} \
-        ${proxy_command} \
-        && virtualenv -p `which ${python}` ${system_pkgs_flag} ${venv_dir} \
-        && ${venv_dir}/bin/pip install ${pypi_index} ${proxy_flag} --upgrade ${distribute_pkg} pip",
+      command => "mkdir -p ${venv_dir} ${proxy_command} && virtualenv -p `which ${python}` ${system_pkgs_flag} ${venv_dir} && ${venv_dir}/bin/pip install ${pypi_index} ${proxy_flag} --upgrade ${distribute_pkg} pip",
       user    => $owner,
       creates => $venv_dir,
       path    => [ '/bin', '/usr/bin', '/usr/sbin' ],


### PR DESCRIPTION
Removed multiline backslashes from the execution statement, since this can cause issues with vagrant, linux guest, windows host and shared folders. And it actually failed to run like that on my system. It this fix is bad for readability, but makes it usable on more platforms.
