### PR TITLE
Install pip before distribute

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -99,7 +99,7 @@ define python::virtualenv (
     }
 
     exec { "python_virtualenv_${venv_dir}":
-      command => "mkdir -p ${venv_dir} ${proxy_command} && virtualenv ${system_pkgs_flag} ${venv_dir} && ${venv_dir}/bin/pip --log-file ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} --upgrade ${distribute_pkg} pip",
+      command => "mkdir -p ${venv_dir} ${proxy_command} && virtualenv ${system_pkgs_flag} ${venv_dir} && ${venv_dir}/bin/pip --log-file ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} --upgrade pip ${distribute_pkg}",
       user    => $owner,
       creates => "${venv_dir}/bin/activate",
       path    => [ '/bin', '/usr/bin', '/usr/sbin' ],


### PR DESCRIPTION
A small fix due to the changes in setuptools. Upgrading distribute before pip results in an error on Ubuntu 12.04. Swapping pip and distribute around seems to get work just fine.

```
$ venv/bin/pip install --upgrade distribute pip
Downloading/unpacking distribute from https://pypi.python.org/packages/source/d/distribute/distribute-0.7.3.zip#md5=c6c59594a7b180af57af8a0cc0cf5b4a
  Using download cache from /home/mwilliamson/.cache/pip-download-cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fd%2Fdistribute%2Fdistribute-0.7.3.zip
  Running setup.py egg_info for package distribute

Downloading/unpacking pip from https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#md5=cbb27a191cebc58997c4da8513863153
  Using download cache from /home/mwilliamson/.cache/pip-download-cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fp%2Fpip%2Fpip-1.3.1.tar.gz
  Running setup.py egg_info for package pip

    warning: no files found matching '*.html' under directory 'docs'
    warning: no previously-included files matching '*.txt' found under directory 'docs/_build'
    no previously-included directories found matching 'docs/_build/_sources'
Downloading/unpacking setuptools>=0.7 (from distribute)
  Using download cache from /home/mwilliamson/.cache/pip-download-cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fs%2Fsetuptools%2Fsetuptools-0.8.tar.gz
  Running setup.py egg_info for package setuptools

Installing collected packages: distribute, pip, setuptools
  Found existing installation: distribute 0.6.24
    Uninstalling distribute:
      Successfully uninstalled distribute
  Running setup.py install for distribute

  Found existing installation: pip 1.1
    Uninstalling pip:
      Successfully uninstalled pip
  Running setup.py install for pip
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools
    Complete output from command /tmp/python-test/venv/bin/python -c "import setuptools;__file__='/tmp/python-test/venv/build/pip/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --single-version-externally-managed --record /tmp/pip-wiveYj-record/install-record.txt --install-headers /tmp/python-test/venv/include/site/python2.7:
    Traceback (most recent call last):

  File "<string>", line 1, in <module>

ImportError: No module named setuptools

----------------------------------------
  Rolling back uninstall of pip
Exception:
Traceback (most recent call last):
  File "/tmp/python-test/venv/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/basecommand.py", line 104, in main
    status = self.run(options, args)
  File "/tmp/python-test/venv/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/commands/install.py", line 250, in run
    requirement_set.install(install_options, global_options)
  File "/tmp/python-test/venv/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/req.py", line 1137, in install
    requirement.rollback_uninstall()
  File "/tmp/python-test/venv/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/req.py", line 491, in rollback_uninstall
    self.uninstalled.rollback()
  File "/tmp/python-test/venv/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/req.py", line 1450, in rollback
    pth.rollback()
AttributeError: 'str' object has no attribute 'rollback'

Storing complete log in /home/mwilliamson/.pip/pip.log
```
