### PR TITLE
Added src parameter for pip in python::requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Installs and manages Python packages from requirements file.
 
 **owner** - The owner of the virtualenv to ensure that packages are installed with the correct permissions (must be specified). Default: root
 
+**src** - The ``--src`` parameter to ``pip``, used to specify where to install ``--editable`` resources; by default no ``--src`` parameter is passed to ``pip``.
+
 **group** - The group that was used to create the virtualenv.  This is used to create the requirements file with correct permissions if it's not present already.
 
 	python::requirements { '/var/www/project1/requirements.txt':

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -19,6 +19,11 @@
 # [*proxy*]
 #  Proxy server to use for outbound connections. Default: none
 #
+# [*src*]
+# Pip --src parameter; if the requirements file contains --editable resources,
+# this parameter specifies where they will be installed. See the pip
+# documentation for more. Default: none (i.e. use the pip default).
+#
 # [*environment*]
 #  Additional environment variables required to install the packages. Default: none
 #
@@ -41,6 +46,7 @@ define python::requirements (
   $owner        = 'root',
   $group        = 'root',
   $proxy        = false,
+  $src          = false,
   $environment = []
 ) {
 
@@ -63,6 +69,11 @@ define python::requirements (
     default  => "--proxy=${proxy}",
   }
 
+  $src_flag = $src ? {
+    false   => '',
+    default => "--src=${src}",
+  }
+
   # This will ensure multiple python::virtualenv definitions can share the
   # the same requirements file.
   if !defined(File[$requirements]) {
@@ -79,7 +90,7 @@ define python::requirements (
 
   exec { "python_requirements${name}":
     provider    => shell,
-    command     => "${pip_env} --log-file ${cwd}/pip.log install ${proxy_flag} -r ${requirements}",
+    command     => "${pip_env} --log-file ${cwd}/pip.log install ${proxy_flag} ${src_flag} -r ${requirements}",
     refreshonly => true,
     timeout     => 1800,
     user        => $owner,


### PR DESCRIPTION
A requirements file can have `--editable` resources; in such a case the pip default is to install them in `~/src/`, which can be unsuitable; for example, if run by root, `/root/src/` is usually unreadable by other users. pip provides an `--src` parameter to specify an alternative directory. This is useful for installing requirements systemwide, outside a virtualenv.
