### PR TITLE
Add options install_args and uninstall_args.

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -35,12 +35,14 @@
 # Fotis Gimian
 #
 define python::pip (
-  $ensure      = present,
-  $virtualenv  = 'system',
-  $url         = false,
-  $owner       = 'root',
-  $proxy       = false,
-  $environment = []
+  $ensure          = present,
+  $virtualenv      = 'system',
+  $url             = false,
+  $owner           = 'root',
+  $proxy           = false,
+  $environment     = [],
+  $install_args    = '',
+  $uninstall_args  = '',
 ) {
 
   # Parameter validation
@@ -80,7 +82,7 @@ define python::pip (
   case $ensure {
     present: {
       exec { "pip_install_${name}":
-        command     => "$pip_env --log-file ${cwd}/pip.log install ${proxy_flag} ${source}",
+        command     => "$pip_env --log-file ${cwd}/pip.log install $install_args ${proxy_flag} ${source}",
         unless      => "$pip_env freeze | grep -i -e ${grep_regex}",
         user        => $owner,
         environment => $environment,
@@ -89,7 +91,7 @@ define python::pip (
 
     default: {
       exec { "pip_uninstall_${name}":
-        command     => "echo y | $pip_env uninstall ${proxy_flag} ${name}",
+        command     => "echo y | $pip_env uninstall $uninstall_args ${proxy_flag} ${name}",
         onlyif      => "$pip_env freeze | grep -i -e ${grep_regex}",
         user        => $owner,
         environment => $environment,


### PR DESCRIPTION
Modern pip does not install what it considers 'pre-release' versions
unless '--pre' is given as argument. This change adds a mechanism for
supplying the '--pre' argument or any other argument deemed necessary.
