### PR TITLE
Expose user/group config to configure gunicorn

### DIFF
--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -37,6 +37,8 @@
 #   dir         => '/var/www/project1/current',
 #   bind        => 'unix:/tmp/gunicorn.socket',
 #   environment => 'prod',
+#   owner       => 'www-data',
+#   group       => 'www-data',
 #   template    => 'python/gunicorn.erb',
 # }
 #
@@ -53,6 +55,8 @@ define python::gunicorn (
   $dir           = false,
   $bind          = false,
   $environment   = false,
+  $owner         = 'www-data',
+  $group         = 'www-data',
   $template      = 'python/gunicorn.erb',
 ) {
 

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -13,8 +13,8 @@ CONFIG = {
   },
 <% end -%>
   'working_dir': '<%= @dir %>',
-  'user': 'www-data',
-  'group': 'www-data',
+  'user': '<%= @owner %>',
+  'group': '<%= @group %>',
 <% if @virtualenv -%>
   'python': '<%= @virtualenv %>/bin/python',
 <% else -%>


### PR DESCRIPTION
gunicorn setup was forcing users to run their processes with the user www-data
which isn't available in all distributions (for instance Fedora Linux) and
it's a good practice to run each website under different users to reduce
security issues

This change won't affect existing users, because by default user and group keep using www-data.
