### PR TITLE
Wheel support in pip needs current setuptools

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -112,7 +112,7 @@ define python::virtualenv (
 
     $distribute_pkg = $distribute ? {
       true     => 'distribute',
-      default  => '',
+      default  => 'setuptools',
     }
     $pypi_index = $index ? {
         false   => '',


### PR DESCRIPTION
When virtualenvs are used without distribute and an old setuptools python package is installed in the system, upgrading pip in the virtualenv won't ensure setuptools > 0.8 is installed which is required by the pip wheel command. This patch upgrades setuptools if distribute isn't used.
