### PR TITLE
Drop stderr in pip --version

### DIFF
--- a/lib/facter/pip_version.rb
+++ b/lib/facter/pip_version.rb
@@ -5,7 +5,7 @@ pkg = Puppet::Type.type(:package).new(:name => "python-pip")
 Facter.add("pip_version") do
   has_weight 100
   setcode do
-    /^pip (\d+\.\d+\.?\d*).*$/.match(Facter::Util::Resolution.exec('pip --version'))[1]
+    /^pip (\d+\.\d+\.?\d*).*$/.match(Facter::Util::Resolution.exec('pip --version 2>/dev/null'))[1]
   end
 end
 


### PR DESCRIPTION
In pip_version fact drop stderr when calling `pip --version` command. Some old versions of `pip` doesn't support `--version` argument. E.g. on Debian 6 (python-pip_0.7.2-1):

```
# pip --version
Usage: pip COMMAND [OPTIONS]

pip: error: no such option: --version
```

and facter then complains:

```
# facter -p >/dev/null
Usage: pip COMMAND [OPTIONS]

pip: error: no such option: --version
```
