### PR TITLE
prevent Facter error when packages not installed

### DIFF
--- a/lib/facter/pip_version.rb
+++ b/lib/facter/pip_version.rb
@@ -12,7 +12,7 @@ end
 Facter.add("pip_version") do
   has_weight 50
   setcode do
-    if pkg.retrieve[pkg.property(:ensure)] != 'purged'
+    unless [:absent,'purged'].include?(pkg.retrieve[pkg.property(:ensure)])
         /^.*(\d+\.\d+\.\d+).*$/.match(pkg.retrieve[pkg.property(:ensure)])[1]
     end
   end

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -5,7 +5,7 @@ pkg = Puppet::Type.type(:package).new(:name => "python")
 
 Facter.add("system_python_version") do
   setcode do
-    if pkg.retrieve[pkg.property(:ensure)] != 'purged'
+    unless [:absent,'purged'].include?(pkg.retrieve[pkg.property(:ensure)])
         /^(\d+\.\d+\.\d+).*$/.match(pkg.retrieve[pkg.property(:ensure)])[1]
     end
   end
@@ -21,7 +21,7 @@ end
 Facter.add("python_version") do
   has_weight 50
   setcode do
-    if pkg.retrieve[pkg.property(:ensure)] != 'purged'
+    unless [:absent,'purged'].include?(pkg.retrieve[pkg.property(:ensure)])
         /^.*(\d+\.\d+\.\d+).*$/.match(pkg.retrieve[pkg.property(:ensure)])[1]
     end
   end

--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -12,7 +12,7 @@ end
 Facter.add("virtualenv_version") do
   has_weight 50
   setcode do
-    if pkg.retrieve[pkg.property(:ensure)] != 'purged'
+    unless [:absent,'purged'].include?(pkg.retrieve[pkg.property(:ensure)])
         /^.*(\d+\.\d+\.\d+).*$/.match(pkg.retrieve[pkg.property(:ensure)])[1]
     end
   end


### PR DESCRIPTION
on RHEL systems, `pkg.retrieve[pkg.property(:ensure)]` returns `:absent`
when a package is not installed; this can generate an unsightly error
when running these facts on a RHEL system where the necessary OS
packages are not installed:

```
[root@gepeto ~]# facter -p osfamily
RedHat
[root@gepeto ~]# facter -p lsbmajdistrelease
5
[root@gepeto ~]# grep version /etc/puppet/modules/python/Modulefile
version      '1.6.3'
[root@gepeto ~]# facter -p virtualenv_version pip_version
Could not retrieve virtualenv_version: can't convert Symbol into String
Could not retrieve pip_version: undefined method `[]' for nil:NilClass
Could not retrieve pip_version: can't convert Symbol into String
pip_version =>
virtualenv_version =>
```

Fixes #50
