### PR TITLE
Make venv_dir into a class parameter

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -76,9 +76,9 @@ define python::virtualenv (
   $group            = 'root',
   $proxy            = false,
   $environment      = [],
-  $path             = [ '/bin', '/usr/bin', '/usr/sbin' ]
-  $cwd          = undef,
-  $timeout      = 1800
+  $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],
+  $cwd              = undef,
+  $timeout          = 1800
 ) {
 
   if $ensure == 'present' {


### PR DESCRIPTION
venv_dir in the virtualenv type should be able to be overridden via class parameter. Also fixes all currently outstanding linting issues.
