### PR TITLE
Quote upper case strings for future parser compatibility

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,8 +22,8 @@ class python::install {
   }
 
   $pythondev = $::osfamily ? {
-    RedHat => "${python}-devel",
-    Debian => "${python}-dev"
+    'RedHat' => "${python}-devel",
+    'Debian' => "${python}-dev"
   }
 
   $dev_ensure = $python::dev ? {


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/PUP-2800 explains why it is required to quote upper case words.
