### PR TITLE
Changed order pattern in init.pp to support the Anchor pattern to contain dependencies.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,9 +53,10 @@ class python (
     fail("Module is not compatible with ${::operatingsystem}")
   }
 
-  Class['python::install'] -> Class['python::config']
-
-  include python::install
-  include python::config
+  # Anchor pattern to contain dependencies
+  anchor { 'python::begin': } ->
+  class { 'python::install': } ->
+  class { 'python::config': } ->
+  anchor { 'python::end': }
 
 }


### PR DESCRIPTION
Added anchor pattern to contain dependencies and maintain proper order of execution.

See bug #8040 https://projects.puppetlabs.com/issues/8040
