### PR TITLE
allow to specify directory from which to run the "pip install" command

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -154,6 +154,7 @@ define python::virtualenv (
         proxy        => $proxy,
         owner        => $owner,
         group        => $group,
+        cwd          => $cwd,
         require      => Exec["python_virtualenv_${venv_dir}"],
       }
     }


### PR DESCRIPTION
If a requirements.txt includes relative paths (like `../src`), it seems like `pip install` must be run from within that directory. This works correctly for the first installation when the virtualenv is created, but if a change is detected in requirements.txt by puppet, `pip install` will be executed again, but fail.

This change fixes this for me.

As `$cwd` was already defined, I renamed that to `$rootdir` as that seems to be a more apropriate name.
