### PR TITLE
Handle case when virtualenv_version fact is not available.

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -108,7 +108,11 @@ define python::virtualenv (
     } elsif (( versioncmp($::virtualenv_version,'1.7') < 0 ) and ( $systempkgs == false )) {
       $system_pkgs_flag = '--no-site-packages'
     } else {
-      $system_pkgs_flag = ''
+      $system_pkgs_flag = $systempkgs ? {
+        true    => '--system-site-packages',
+        false   => '--no-site-packages',
+        default => fail('Invalid value for systempkgs. Boolean value is expected')
+      }
     }
 
     $distribute_pkg = $distribute ? {


### PR DESCRIPTION
As specified in #94, when their is no way to find virtualenv version,
fall back to user request.

When fact _virtualenv_version_ is not yet available, stupidly trust user
input and force `systempkgs` option without taking care of virtualenv
version.
1. If the option `--no-site-packages` or `--system-site-packages`  is not recognized by the installed version of
   virtualenv, _Exec_ will fail and dependencies will not be processed (this will avoid some services to actually seem to work and some times later fail because of the lack of system site packages).
2. On the next puppet execution, fact _virtualenv_version_ will be available and process should work as
   expected.
