### PR TITLE
Don't override PATH while installing requirements.txt

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -107,7 +107,6 @@ define python::requirements (
     user        => $owner,
     subscribe   => File[$requirements],
     environment => $environment,
-    path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
   }
 
 }


### PR DESCRIPTION
Setting the path here causes installation failures if some package
in requirements.txt needs tools which happen to be installed in
a non-system location.

Leave path alone so caller can use Exec { path=>[...] } or similar
to locate the desired tools.

Signed-off-by: Ray Lehtiniemi rayl@mail.com
