### PR TITLE
puppet-lint: removed unused var 'use_pkgname'

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -185,7 +185,7 @@ define python::pip (
     default: {
       # Anti-action, uninstall.
       exec { "pip_uninstall_${name}":
-        command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${use_pkgname}",
+        command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag}",
         onlyif      => "${pip_env} freeze | grep -i -e ${grep_regex}",
         user        => $owner,
         environment => $environment,


### PR DESCRIPTION
Remove use_pkgname variable from pip uninstall.
It is not declared anywhere and as such is breaking the lint tests.
