### PR TITLE
Removed support for ruby 1.8.7 during tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0


### PR DESCRIPTION
This will remove ruby 1.8.7 from the test run, as ruby 1.8.7 no longer has support.
This fixes the broken build and returns the passing status.

If you enable the hook on https://travis-ci.org we will be able see the build results for reach pull request.

![puppet-python-build](https://travis-ci.org/daniellawrence/puppet-python.svg?branch=remove_ruby_1.8.7_support)
