### PR TITLE
This module is not depended on Puppet Labs Concat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    # "concat": "git://github.com/puppetlabs/puppetlabs-concat.git"
   symlinks:
     "python": "#{source_dir}"


### PR DESCRIPTION
Thus removed comment text from fixtures.yml
