### PR TITLE
Proposed fix for ticket 66: allow extra arguments when using requirement...

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -35,6 +35,9 @@
 # [*cwd*]
 #  The directory from which to run the "pip install" command. Default: undef
 #
+# [*extra_pip_args*]
+# Extra arguments to pass to pip after the requirements file
+#
 # === Examples
 #
 # python::requirements { '/var/www/project1/requirements.txt':
@@ -58,6 +61,7 @@ define python::requirements (
   $environment  = [],
   $forceupdate  = false,
   $cwd          = undef,
+  $extra_pip_args = '',
 ) {
 
   if $virtualenv == 'system' and ($owner != 'root' or $group != 'root') {
@@ -100,7 +104,7 @@ define python::requirements (
 
   exec { "python_requirements${name}":
     provider    => shell,
-    command     => "${pip_env} --log ${rootdir}/pip.log install ${proxy_flag} ${src_flag} -r ${requirements}",
+    command     => "${pip_env} --log ${rootdir}/pip.log install ${proxy_flag} ${src_flag} -r ${requirements} $extra_pip_args",
     refreshonly => !$forceupdate,
     timeout     => 1800,
     cwd         => $cwd,

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -46,6 +46,9 @@
 # [*timeout*]
 #  The maximum time in seconds the "pip install" command should take. Default: 1800
 #
+# [*extra_pip_args*]
+#  Extra arguments to pass to pip after requirements file.  Default: blank
+#
 # === Examples
 #
 # python::virtualenv { '/var/www/project1':
@@ -78,7 +81,8 @@ define python::virtualenv (
   $environment      = [],
   $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],
   $cwd              = undef,
-  $timeout          = 1800
+  $timeout          = 1800,
+  $extra_pip_args   = ''
 ) {
 
   if $ensure == 'present' {
@@ -137,6 +141,8 @@ define python::virtualenv (
       group  => $group,
     }
 
+
+
     exec { "python_virtualenv_${venv_dir}":
       command     => "true ${proxy_command} && virtualenv ${system_pkgs_flag} -p ${python} ${venv_dir} && ${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
       user        => $owner,
@@ -150,7 +156,7 @@ define python::virtualenv (
 
     if $requirements {
       exec { "python_requirements_initial_install_${requirements}_${venv_dir}":
-        command     => "${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag -r ${requirements}",
+        command     => "${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag -r ${requirements} $extra_pip_args",
         refreshonly => true,
         timeout     => $timeout,
         user        => $owner,
@@ -167,6 +173,7 @@ define python::virtualenv (
         group        => $group,
         cwd          => $cwd,
         require      => Exec["python_virtualenv_${venv_dir}"],
+	extra_pip_args => $extra_pip_args,
       }
     }
   } elsif $ensure == 'absent' {


### PR DESCRIPTION
...s

Adds an extra argument "extra_pip_args" that can be set to any string; it will be included after
the requirements file is specified to allow (for example) non pypi packages to be built.
