### PR TITLE
Return 'absent' instead of nil

### DIFF
--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -6,7 +6,7 @@ Facter.add("virtualenv_version") do
   has_weight 100
   setcode do
     begin
-      Facter::Util::Resolution.exec('virtualenv --version')
+      Facter::Util::Resolution.exec('virtualenv --version') || "absent"
     rescue
       false
     end


### PR DESCRIPTION
The current ::virtualenv_version fact returns nil when virtualenv isn't installed. In the module itself however, line 115 of virtualenv.pp requires $::virtualenv_version to be set to something.

The choices are to either allow for null or return something that versioncmp can handle.
