### PR TITLE
adding python::gunicorn template timeout var with default of 30 sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Manages Gunicorn virtual hosts.
 
 **osenv** - Allows setting environment variables for the gunicorn service. Accepts a hash of 'key': 'value' pairs. Default: false
 
+**timeout** - Allows setting the gunicorn idle worker process time before being killed. The unit of time is seconds. Default: 30
+
 **template** - Which ERB template to use. Default: python/gunicorn.erb
 
 ```puppet
@@ -188,6 +190,7 @@ Manages Gunicorn virtual hosts.
     environment => 'prod',
     appmodule   => 'app:app',
     osenv       => { 'DBHOST' => 'dbserver.example.com' },
+    timeout     => 30,
     template    => 'python/gunicorn.erb',
   }
 ```

--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -34,6 +34,11 @@
 #  hash of 'key': 'value' pairs.
 #  Default: false
 #
+# [*timeout*]
+#  Allows setting the gunicorn idle worker process time before being killed.
+#  The unit of time is seconds.
+#  Default: 30
+#
 # [*template*]
 #  Which ERB template to use. Default: python/gunicorn.erb
 #
@@ -50,6 +55,7 @@
 #   group       => 'www-data',
 #   appmodule   => 'app:app',
 #   osenv       => { 'DBHOST' => 'dbserver.example.com' },
+#   timeout     => 30,
 #   template    => 'python/gunicorn.erb',
 # }
 #
@@ -70,6 +76,7 @@ define python::gunicorn (
   $group         = 'www-data',
   $appmodule     = 'app:app',
   $osenv         = false,
+  $timeout       = 30,
   $template      = 'python/gunicorn.erb',
 ) {
 

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -32,7 +32,7 @@ CONFIG = {
     '--bind=<%= @bind %>',
 <% end -%>
     '--workers=<%= @processorcount.to_i*2 %>',
-    '--timeout=30',
+    '--timeout=<%= @timeout %>',
 <% if @mode != 'django' -%>
     '<%= @appmodule %>',
 <% end -%>

--- a/tests/gunicorn.pp
+++ b/tests/gunicorn.pp
@@ -13,5 +13,6 @@ python::gunicorn { 'vhost':
   environment => 'prod',
   appmodule   => 'app:app',
   osenv       => { 'DBHOST' => 'dbserver.example.com' },
+  timeout     => 30,
   template    => 'python/gunicorn.erb',
 }


### PR DESCRIPTION
Adding the ability to override the default gunicorn worker process timeout of 30 sec. This can be set with:

```
python::gunicorn { 'app':
  timeout => 60
}
```

resolves #137 
