### PR TITLE
Add fix to detect older puppet while setting allow_virtual for > 3.6

### DIFF
--- a/lib/facter/pip_version.rb
+++ b/lib/facter/pip_version.rb
@@ -1,7 +1,11 @@
 # Make pip version available as a fact
 # Works with pip loaded and without, pip installed using pip  and package installed
 require 'puppet'
-pkg = Puppet::Type.type(:package).new(:name => "python-pip")
+if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+  pkg = Puppet::Type.type(:package).new(:name => 'python-pip', :allow_virtual => 'false')
+else
+  pkg = Puppet::Type.type(:package).new(:name => 'python-pip')
+end
 Facter.add("pip_version") do
   has_weight 100
   setcode do

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -1,8 +1,11 @@
 # Make python versions available as facts
 # In lists default python and system python versions
 require 'puppet'
-pkg = Puppet::Type.type(:package).new(:name => "python")
-
+if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+  pkg = Puppet::Type.type(:package).new(:name => 'python', :allow_virtual => 'false')
+else
+  pkg = Puppet::Type.type(:package).new(:name => 'python')
+end
 Facter.add("system_python_version") do
   setcode do
     begin

--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -1,7 +1,11 @@
 # Make virtualenv version available as a fact
 # Works with virualenv loaded and without, pip installed and package installed
 require 'puppet'
-pkg = Puppet::Type.type(:package).new(:name => "virtualenv")
+if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+  pkg = Puppet::Type.type(:package).new(:name => 'virtualenv', :allow_virtual => 'false')
+else
+  pkg = Puppet::Type.type(:package).new(:name => 'virtualenv')
+end
 Facter.add("virtualenv_version") do
   has_weight 100
   setcode do


### PR DESCRIPTION
This should resolve the problems in #122 without triggering the compatibility warnings in #140. Tested against Puppet 3.5, but no earlier.
