### PR TITLE
added support to pip install from local directory

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -134,8 +134,9 @@ define python::pip (
   }
 
   $source = $url ? {
-    false   => $pkgname,
-    default => "${url}#egg=${egg_name}",
+    false               => $pkgname,
+    /^(\/|[a-zA-Z]\:)/  => $url,
+    default             => "${url}#egg=${egg_name}",
   }
 
   # We need to jump through hoops to make sure we issue the correct pip command


### PR DESCRIPTION
Usage example:

```
  ::python::pip { 'my_py_pkg_virtualenv':
    pkgname     => 'my_py_pkg',
    url         => '/home/devuser/my_py_pkg_source',
    virtualenv  => '/opt/virtualenv'
  }
```
