### PR TITLE
Amended facter pupperversion check to cope with Enterprise string

### DIFF
--- a/lib/facter/pip_version.rb
+++ b/lib/facter/pip_version.rb
@@ -2,7 +2,15 @@
 # Works with pip loaded and without, pip installed using pip  and package installed
 require 'puppet'
 require 'rubygems'
-if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+
+facter_puppet_version = Facter.value(:puppetversion)
+facter_is_pe = Facter.value(:is_pe)
+
+if facter_is_pe
+    facter_puppet_version = facter_puppet_version.to_s.split(' ')[0]
+end
+
+if Gem::Version.new(facter_puppet_version) >= Gem::Version.new('3.6')
   pkg = Puppet::Type.type(:package).new(:name => 'python-pip', :allow_virtual => 'false')
 else
   pkg = Puppet::Type.type(:package).new(:name => 'python-pip')

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -2,7 +2,15 @@
 # In lists default python and system python versions
 require 'puppet'
 require 'rubygems'
-if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+
+facter_puppet_version = Facter.value(:puppetversion)
+facter_is_pe = Facter.value(:is_pe)
+
+if facter_is_pe
+    facter_puppet_version = facter_puppet_version.to_s.split(' ')[0]
+end
+
+if Gem::Version.new(facter_puppet_version) >= Gem::Version.new('3.6')
   pkg = Puppet::Type.type(:package).new(:name => 'python', :allow_virtual => 'false')
 else
   pkg = Puppet::Type.type(:package).new(:name => 'python')

--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -2,7 +2,15 @@
 # Works with virualenv loaded and without, pip installed and package installed
 require 'puppet'
 require 'rubygems'
-if Gem::Version.new(Facter.value(:puppetversion)) >= Gem::Version.new('3.6')
+
+facter_puppet_version = Facter.value(:puppetversion)
+facter_is_pe = Facter.value(:is_pe)
+
+if facter_is_pe
+    facter_puppet_version = facter_puppet_version.to_s.split(' ')[0]
+end
+
+if Gem::Version.new(facter_puppet_version) >= Gem::Version.new('3.6')
   pkg = Puppet::Type.type(:package).new(:name => 'virtualenv', :allow_virtual => 'false')
 else
   pkg = Puppet::Type.type(:package).new(:name => 'virtualenv')


### PR DESCRIPTION
When Puppet Enterprise is installed, facter returns both Open Source & Enterprise versions which causes Gem::Version.new() to throw an error "malformed version number"
Example version string:
_puppetversion => 3.6.2 (Puppet Enterprise 3.3.2)_

As you've already got a dependency to puppetlabs-stdlib I've made a call to retrieve the is_pe Facter variable ( https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/lib/facter/pe_version.rb ) to determine if we need to split the Open Source version number from the Enterprise. 

Tested with **puppet-python 1.7.15** & **stdlib 4.4.0**. Please feel free to amend and improve as necessary but this was blocking us installing your module on a Puppet Enterprise node.

Cheers, Jonathan
