### PR TITLE
Add pip install support for "ensure => <Version>" when using VCS source

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -153,60 +153,85 @@ define python::pip (
   # version, this makes sure we only use wheels if they are supported and
   # installed
 
-
-  case $ensure {
-    /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/: {
-      # Version formats as per http://guide.python-distribute.org/specification.html#standard-versioning-schemes
-      # Explicit version.
-      exec { "pip_install_${name}":
-        command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} ;}",
-        unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
-        user        => $owner,
-        cwd         => $cwd,
-        environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
-        timeout     => $timeout,
-      }
+  # Explicit version out of VCS when PIP supported URL is provided
+  if $source =~ /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ {
+      if $ensure != present and $ensure != latest {
+        exec { "pip_install_${name}":
+          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure} ;}",
+          unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          user        => $owner,
+          cwd         => $cwd,
+          environment => $environment,
+          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+          timeout     => $timeout,
+          }
+        }
+    else {
+          exec { "pip_install_${name}":
+            command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
+            unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+            user        => $owner,
+            cwd         => $cwd,
+            environment => $environment,
+            path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+            timeout     => $timeout,
+        }
     }
-
-    present: {
-      # Whatever version is available.
-      exec { "pip_install_${name}":
-        command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
-        unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
-        user        => $owner,
-        cwd         => $cwd,
-        environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
-        timeout     => $timeout,
+  }
+  else {
+    case $ensure {
+      /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/: {
+        # Version formats as per http://guide.python-distribute.org/specification.html#standard-versioning-schemes
+        # Explicit version.
+        exec { "pip_install_${name}":
+          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} ;}",
+          unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          user        => $owner,
+          cwd         => $cwd,
+          environment => $environment,
+          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+          timeout     => $timeout,
+        }
       }
-    }
 
-    latest: {
-      # Latest version.
-      exec { "pip_install_${name}":
-        command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install --upgrade \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install --upgrade ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
-        unless      => "${pip_env} search ${source} | grep -i INSTALLED | grep -i latest",
-        user        => $owner,
-        cwd         => $cwd,
-        environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
-        timeout     => $timeout,
+      present: {
+        # Whatever version is available.
+        exec { "pip_install_${name}":
+          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
+          unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          user        => $owner,
+          cwd         => $cwd,
+          environment => $environment,
+          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+          timeout     => $timeout,
+        }
       }
-    }
 
-    default: {
-      # Anti-action, uninstall.
-      exec { "pip_uninstall_${name}":
-        command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag}",
-        onlyif      => "${pip_env} freeze | grep -i -e ${grep_regex}",
-        user        => $owner,
-        cwd         => $cwd,
-        environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
-        timeout     => $timeout,
+      latest: {
+        # Latest version.
+        exec { "pip_install_${name}":
+          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install --upgrade \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install --upgrade ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
+          unless      => "${pip_env} search ${source} | grep -i INSTALLED | grep -i latest",
+          user        => $owner,
+          cwd         => $cwd,
+          environment => $environment,
+          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+          timeout     => $timeout,
+        }
+      }
+
+      default: {
+        # Anti-action, uninstall.
+        exec { "pip_uninstall_${name}":
+          command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag}",
+          onlyif      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          user        => $owner,
+          cwd         => $cwd,
+          environment => $environment,
+          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
+          timeout     => $timeout,
+        }
       }
     }
   }
-
 }


### PR DESCRIPTION
PIP-installable packages from pip supported version control systems. Fairly simplistic use of the "ensure" value. Not sure if some extra work needs to be done around checking the current environments installed packages.
