### PR TITLE
Fix for url detection for VCS

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -136,6 +136,7 @@ define python::pip (
   $source = $url ? {
     false               => $pkgname,
     /^(\/|[a-zA-Z]\:)/  => $url,
+    /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ => url,
     default             => "${url}#egg=${egg_name}",
   }
 


### PR DESCRIPTION
"egg=PkgName" added to URL breaks PIP installation when specifying VCS. Added regex for detecting VCS URL, but it could be rolled into the previous regex. Tested w/ "ensure  => Version#". 

Sorry I missed this in my earlier pull.
