### PR TITLE
Bugfix: "$url" variable misname in pip.pp for VCS source assignment

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -136,7 +136,7 @@ define python::pip (
   $source = $url ? {
     false               => $pkgname,
     /^(\/|[a-zA-Z]\:)/  => $url,
-    /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ => url,
+    /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ => $url,
     default             => "${url}#egg=${egg_name}",
   }
 


### PR DESCRIPTION
Sorry again, I poorly copied my work from my remote environment and screwed this up. 
