### PR TITLE
add a defined type for managing arbitrary python dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,36 @@ Manages Gunicorn virtual hosts.
   }
 ```
 
+### python::dotfile
+
+Manages arbitrary python dotiles with a simple config hash.
+
+**ensure** - present/absent. Default: present
+
+**filename** - Default: $title
+
+**mode** - Default: 0644
+
+**owner** - Default: root
+
+**group** - Default: root
+
+**config** Config hash. This will be expanded to an ini-file. Default: {}
+
+```puppet
+python::dotfile { '/var/lib/jenkins/.pip/pip.conf':
+  ensure => present,
+  owner  => 'jenkins',
+  group  => 'jenkins',
+  config => {
+    'global' => {
+      'index-url       => 'https://mypypi.acme.com/simple/'
+      'extra-index-url => https://pypi.risedev.at/simple/
+    }
+  }
+}
+```
+
 ## Authors
 
 [Sergey Stankevich](https://github.com/stankevich)

--- a/manifests/dotfile.pp
+++ b/manifests/dotfile.pp
@@ -1,0 +1,61 @@
+# == Define: python::dotfile
+#
+# Manages any python dotfiles with a simple config hash.
+#
+# === Parameters
+#
+# [*ensure*]
+#  present|absent. Default: present
+#
+# [*filename*]
+#  Filename. Default: $title
+#
+# [*mode*]
+#  File mode. Default: 0644
+#
+# [*owner*]
+# [*group*]
+#  Owner/group. Default: `root`/`root`
+#
+# [*config*]
+#  Config hash. This will be expanded to an ini-file. Default: {}
+#
+# === Examples
+#
+# python::dotfile { '/var/lib/jenkins/.pip/pip.conf':
+#   ensure => present,
+#   owner  => 'jenkins',
+#   group  => 'jenkins',
+#   config => {
+#     'global' => {
+#       'index-url       => 'https://mypypi.acme.com/simple/'
+#       'extra-index-url => https://pypi.risedev.at/simple/
+#     }
+#   }
+# }
+#
+#
+define python::dotfile (
+  $ensure   = 'present',
+  $filename = $title,
+  $owner    = 'root',
+  $group    = 'root',
+  $mode     = '0644',
+  $config   = {},
+) {
+  $parent_dir = dirname($filename)
+
+  exec { "create ${title}'s parent dir":
+    command => "install -o ${owner} -g ${group} -d ${parent_dir}",
+    path    => [ '/usr/bin', '/bin', '/usr/local/bin', ],
+    creates => $parent_dir,
+  }
+
+  file { $filename:
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    content => template("${module_name}/inifile.erb"),
+    require => Exec["create ${title}'s parent dir"],
+  }
+}

--- a/templates/inifile.erb
+++ b/templates/inifile.erb
@@ -1,0 +1,8 @@
+# this file is managed by puppet
+<%- @config.sort.map do |section,conf| -%>
+[<%= section -%>]
+<%-   conf.sort.map do |key,value| -%>
+<%= key %> = <%= value %>
+<%-   end -%>
+
+<%- end -%>


### PR DESCRIPTION
python dotfiles are user-based ini-files.
this defined type gives our users the ability to define arbitrary python
related .dotfiles. (actually: arbitrary ini-files ;)

This pr closes #87