### PR TITLE
Relax virtualenv directory mode to 0755

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -32,7 +32,7 @@
 #  The group relating to the virtualenv being manipulated. Default: root
 #
 # [*mode*]
-# Optionally specify directory mode. Default: 750
+# Optionally specify directory mode. Default: 0755
 #
 # [*proxy*]
 #  Proxy server to use for outbound connections. Default: none
@@ -80,7 +80,7 @@ define python::virtualenv (
   $index            = false,
   $owner            = 'root',
   $group            = 'root',
-  $mode             = '750',
+  $mode             = '0755',
   $proxy            = false,
   $environment      = [],
   $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],


### PR DESCRIPTION
The default directory mode of 750 is too restrictive.

In our case, for gds-operations/puppet-graphite, it prevents daemons from
being able to start as non-root users. While it's possible for us to provide
a new value as a param it would be a breaking change because it would force
all users of our module to upgrade to 1.8.3 or later.

I think it's reasonable to relax this to a default of 755. This is in
keeping with the default file modes of `python::dotfile`,
`python::requirements` and `python::gunicorn`.

I have also included the fourth digit to clear any suid/sgid/sticky bits.
Per the style guide:

https://docs.puppetlabs.com/guides/style_guide.html#file-modes