### PR TITLE
Validates given virtualenv path is valid

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -87,6 +87,8 @@ define python::pip (
     default  => $virtualenv,
   }
 
+  validate_absolute_path($cwd)
+
   $log = $virtualenv ? {
     'system' => $log_dir,
     default  => $virtualenv,

--- a/spec/acceptance/virtualenv_spec.rb
+++ b/spec/acceptance/virtualenv_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper_acceptance'
+
+describe 'python class' do
+
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class { 'python' :
+        version    => 'system',
+        pip        => true,
+        virtualenv => true,
+      }
+      ->
+      python::virtualenv { 'venv' :
+        ensure => present,
+        systempkgs => false,
+        venv_dir => '/opt/venv',
+        owner => 'root',
+        group => 'root',
+      }
+      ->
+      python::pip { 'rpyc' :
+        ensure => '3.2.3',
+        virtualenv => '/opt/venv',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
+    end
+  end
+end

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'python::pip', :type => :define do
+  let (:title) { 'rpyc' }
+  context "on Debian OS" do
+    let :facts do
+      {
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :lsbdistcodename        => 'squeeze',
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
+        :operatingsystemrelease => '6',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    describe "virtualenv as" do
+      context "fails with non qualified path" do
+        let (:params) {{ :virtualenv => "venv" }}
+        it { is_expected.to raise_error(/"venv" is not an absolute path./) }
+      end
+      context "suceeds with qualified path" do
+        let (:params) {{ :virtualenv => "/opt/venv" }}
+        it { is_expected.to contain_exec("pip_install_rpyc").with_cwd('/opt/venv') }
+      end
+      context "defaults to system" do
+        let (:params) {{ }}
+        it { is_expected.to contain_exec("pip_install_rpyc").with_cwd('/') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The issue was from #165, the virtualenv given didn't give the full path, we now fail early to catch this.

Also adds an rspec to catch this, and a beaker test based on the scenario given in #165