### PR TITLE
Allow user to override the value of $virtualenv in python::virtualenv

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -86,7 +86,8 @@ define python::virtualenv (
   $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],
   $cwd              = undef,
   $timeout          = 1800,
-  $extra_pip_args   = ''
+  $extra_pip_args   = '',
+  $virtualenv       = undef
 ) {
 
   if $ensure == 'present' {
@@ -97,9 +98,11 @@ define python::virtualenv (
       default  => "python${version}",
     }
 
-    $virtualenv = $version ? {
-      'system' => 'virtualenv',
-      default  => "virtualenv-${version}",
+    if $virtualenv == undef {
+      $virtualenv = $version ? {
+        'system' => 'virtualenv',
+        default  => "virtualenv-${version}",
+      }
     }
 
     $proxy_flag = $proxy ? {


### PR DESCRIPTION
I'm having an issue with `python::virtualenv`: when I set `$version` to `pypy` it attempts to create the virtual enviroment with `virtualenv-pypy`. I'm not sure where that binary is meant to come from, but at least on the platform I'm using (CentOS 7) pypy doesn't ship with a `virtualenv-pypy` command. So the point of this pull req is to allow the user to choose which `virtualenv` command to use. Happy to make any necessary modifications, please take a look.