### PR TITLE
Add /usr/local/bin to path for pyenv and virtualenv

### DIFF
--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -55,7 +55,7 @@ define python::pyvenv (
   $owner            = 'root',
   $group            = 'root',
   $mode             = '0755',
-  $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],
+  $path             = [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
   $environment      = [],
 ) {
 

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -83,7 +83,7 @@ define python::virtualenv (
   $mode             = '0755',
   $proxy            = false,
   $environment      = [],
-  $path             = [ '/bin', '/usr/bin', '/usr/sbin' ],
+  $path             = [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
   $cwd              = undef,
   $timeout          = 1800,
   $extra_pip_args   = '',


### PR DESCRIPTION
/usr/local/bin is where get-pip puts pip and virtualenv. We install
using get-pip so that we get a consistent experience across all modern
operating systems.