### PR TITLE
Fix duplicate virtualenv declaration

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -99,10 +99,13 @@ define python::virtualenv (
     }
 
     if $virtualenv == undef {
-      $virtualenv = $version ? {
+      $used_virtualenv = $version ? {
         'system' => 'virtualenv',
         default  => "virtualenv-${version}",
       }
+    }
+    else {
+      $used_virtualenv = $virtualenv;
     }
 
     $proxy_flag = $proxy ? {
@@ -157,7 +160,7 @@ define python::virtualenv (
 
 
     exec { "python_virtualenv_${venv_dir}":
-      command     => "true ${proxy_command} && ${virtualenv} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
+      command     => "true ${proxy_command} && ${used_virtualenv} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
       user        => $owner,
       creates     => "${venv_dir}/bin/activate",
       path        => $path,


### PR DESCRIPTION
Tests on this module are failing with

Error: Cannot reassign variable virtualenv at
/etc/puppet/modules/python/manifests/virtualenv.pp:102

According to puppet, variable reassignment is not allowed:
https://docs.puppetlabs.com/puppet/latest/reference/
lang_variables.html#no-reassignment

Using a new var for the reassingment to avoid that problem