### PR TITLE
Fix installation of a package from a VCS (missing egg name in URL)

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -160,7 +160,7 @@ define python::pip (
   if $source =~ /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ {
       if $ensure != present and $ensure != latest {
         exec { "pip_install_${name}":
-          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure} ;}",
+          command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure}#egg=${egg_name} || ${pip_env} --log ${log}/pip.log install ${install_args} ${proxy_flag} ${install_args} ${install_editable} ${source}@${ensure}#egg=${egg_name} ;}",
           unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
           user        => $owner,
           cwd         => $cwd,


### PR DESCRIPTION
AFAIK, we must provide an egg name to url. Otherwise, pip report an error and the command fail.

Originally, I was trying to automate that command: pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.3#egg=ckan'

There is my puppet code to achieve that (with this fix): 

  python::pip { 'ckan' :
    pkgname       => 'ckan',
    ensure        => 'ckan-2.3',
    url           => 'git+https://github.com/ckan/ckan.git',
    egg           => 'ckan',
    virtualenv    => '/usr/lib/ckan/default',
    owner         => $appUser,
    editable      => true
  }