### PR TITLE
Add EPEL dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page  'https://github.com/stankevich/puppet-python'
 
 ## Add dependencies, if any:
 dependency    'puppetlabs/stdlib', '>= 4.0.0'
+dependency    'stahnma/epel', '>= 1.0.1'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,6 +56,16 @@ class python::install {
       package { "python==${python::version}": ensure => latest, provider => pip }
     }
     default: {
+      if $::osfamily == 'RedHat' {
+        if $pip_ensure == present {
+          include 'epel'
+          Class['epel'] -> Package[$pip]
+        }
+        if ($venv_ensure == present) and ($::operatingsystemrelease =~ /^6/) {
+          include 'epel'
+          Class['epel'] -> Package['python-virtualenv']
+        }
+      }
       package { 'python-virtualenv': ensure => $venv_ensure }
       package { $pip: ensure => $pip_ensure }
       package { $pythondev: ensure => $dev_ensure }

--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "stahnma/epel",
+      "version_requirement": ">= 1.0.1"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,6 +27,7 @@ RSpec.configure do |c|
       copy_module_to(host, :source => proj_root, :module_name => 'python')
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       on host, puppet('module install puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module install stahnma-epel'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
This approach to adding the EPEL dependency uses a few more lines of code than the alternative, but it means that the EPEL module only gets called if the OS (RedHat) and OS Version require it.

Note: Even if the EPEL module were included on a different OS (e.g. Ubuntu) the module logic of the EPEL module doesn't do anything unless it's on a RedHat osfamily system.

An alternative method to accomplish this would be to just unconditionally include the EPEL module, and set it as a require for the pip and virtualenv package resources. On Ubuntu this would mean that puppet output would show the EPEL module being used but nothing would be done to the system. On RedHat the EPEL yum repo configs would be installed even if the user was on RHEL 7 and only looking to install virtualenv (not pip) in which case EPEL is not required because RHEL 7 provides virtualenv in the base repositories.

I figured that the method in this PR would be better than the alternative as it would only involve the EPEL module when required, even though that resulted in a couple more lines of conditional logic.

One other thing to note is that regardless of the OS (Ubuntu RedHat), the EPEL module would be downloaded because this PR sets it as a metadata.json dependency. This means on an Ubuntu system, puppet (or librarian-puppet or whatever you use to fetch puppet modules) would download the EPEL module, but would not use it. It would just be in the modules directory unused. I can't think of a way around this because module dependencies (like those recorded in metadata.json) aren't conditional and can't depend on the OS. I don't think it's a big problem though.

Fixes #196 