### PR TITLE
Fix puppet-lint issue from f6d4b30

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -176,14 +176,14 @@ define python::virtualenv (
       }
 
       python::requirements { "${requirements}_${venv_dir}":
-        requirements    => $requirements,
-        virtualenv      => $venv_dir,
-        proxy           => $proxy,
-        owner           => $owner,
-        group           => $group,
-        cwd             => $cwd,
-        require         => Exec["python_virtualenv_${venv_dir}"],
-        extra_pip_args  => $extra_pip_args,
+        requirements   => $requirements,
+        virtualenv     => $venv_dir,
+        proxy          => $proxy,
+        owner          => $owner,
+        group          => $group,
+        cwd            => $cwd,
+        require        => Exec["python_virtualenv_${venv_dir}"],
+        extra_pip_args => $extra_pip_args,
       }
     }
   } elsif $ensure == 'absent' {


### PR DESCRIPTION
Looks like Travis-CI builds are failing due to puppet-lint from f6d4b30 . This should get the builds passing again.