### PR TITLE
Add epel to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "epel": "git://github.com/stahnma/puppet-module-epel.git"
   symlinks:
     "python": "#{source_dir}"


### PR DESCRIPTION
In PR #198 I missed adding epel to the fixtures file which is causing some of the rspec errors