### PR TITLE
Confine puppet facter to Linux

### DIFF
--- a/lib/facter/pip_version.rb
+++ b/lib/facter/pip_version.rb
@@ -15,6 +15,7 @@ else
 end
 
 Facter.add("pip_version") do
+  confine :kernel => :linux
   has_weight 100
   setcode do
     if Facter::Util::Resolution.which('pip')
@@ -24,6 +25,7 @@ Facter.add("pip_version") do
 end
 
 Facter.add("pip_version") do
+  confine :kernel => :linux	
   has_weight 50
   setcode do
     unless [:absent,:purged].include?(pkg.retrieve[pkg.property(:ensure)])

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -15,6 +15,7 @@ else
 end
 
 Facter.add("system_python_version") do
+  confine :kernel => :linux
   setcode do
     unless [:absent,:purged].include?(pkg.retrieve[pkg.property(:ensure)])
       pkg.retrieve[pkg.property(:ensure)]
@@ -23,6 +24,7 @@ Facter.add("system_python_version") do
 end
 
 Facter.add("python_version") do
+  confine :kernel => :linux
   has_weight 100
   setcode do
     if Facter::Util::Resolution.which('python')
@@ -32,6 +34,7 @@ Facter.add("python_version") do
 end
 
 Facter.add("python_version") do
+  confine :kernel => :linux
   has_weight 50
   setcode do
     unless [:absent,:purged].include?(pkg.retrieve[pkg.property(:ensure)])

--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -15,6 +15,7 @@ else
 end
 
 Facter.add("virtualenv_version") do
+  confine :kernel => :linux
   has_weight 100
   setcode do
     if Facter::Util::Resolution.which('virtualenv')
@@ -24,6 +25,7 @@ Facter.add("virtualenv_version") do
 end
 
 Facter.add("virtualenv_version") do
+  confine :kernel => :linux
   has_weight 50
   setcode do
     unless [:absent,:purged].include?(pkg.retrieve[pkg.property(:ensure)])


### PR DESCRIPTION
 This is to make sure it runs on linux os only. We do have stacks comprised of windows & linux machines