### PR TITLE
Make the inclusion of the epel class optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Installs and manages python, python-pip, python-dev, python-virtualenv and Gunic
 
 **manage_gunicorn** - Allow Installation / Removal of Gunicorn. Default: true
 
+**use_epel** - Boolean to determine if the epel class is used. Default: true
+
 ```puppet
   class { 'python' :
     version    => 'system',
@@ -278,4 +280,4 @@ python::python_pips:
 
 ## Authors
 
-[Sergey Stankevich](https://github.com/stankevich) | [Shiva Poudel](https://github.com/shivapoudel)
+[Sergey Stankevich](https://github.com/stankevich) | [Shiva Poudel](https://github.com/shivapoudel) | [Garrett Honeycutt](http://learnpuppet.com)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,9 @@
 #  Default: system default provider
 #  Allowed values: 'pip'
 #
+# [*use_epel*]
+#  Boolean to determine if the epel class is used. Default: true
+#
 # === Examples
 #
 # class { 'python':
@@ -50,6 +53,7 @@
 # === Authors
 #
 # Sergey Stankevich
+# Garrett Honeycutt <code@garretthoneycutt.com>
 #
 class python (
   $version                   = $python::params::version,
@@ -63,6 +67,7 @@ class python (
   $python_pips               = { },
   $python_virtualenvs        = { },
   $python_pyvenvs            = { },
+  $use_epel                  = $python::params::use_epel,
 ) inherits python::params{
 
   # validate inputs
@@ -82,6 +87,7 @@ class python (
   validate_bool($virtualenv)
   validate_bool($gunicorn)
   validate_bool($manage_gunicorn)
+  validate_bool($use_epel)
 
   # Module compatibility check
   $compatible = [ 'Debian', 'RedHat', 'Suse' ]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
-# == Define: python::install
+# == Class: python::install
 #
 # Installs core python packages
 #
@@ -11,8 +11,8 @@
 # Sergey Stankevich
 # Ashley Penney
 # Fotis Gimian
+# Garrett Honeycutt <code@garretthoneycutt.com>
 #
-
 class python::install {
 
   $python = $::python::version ? {
@@ -24,7 +24,7 @@ class python::install {
   $pythondev = $::osfamily ? {
     'RedHat' => "${python}-devel",
     'Debian' => "${python}-dev",
-    'Suse'   => "${python}-devel"
+    'Suse'   => "${python}-devel",
   }
 
   # pip version: use only for installation via os package manager!
@@ -59,12 +59,16 @@ class python::install {
     default: {
       if $::osfamily == 'RedHat' {
         if $pip_ensure == present {
-          include 'epel'
-          Class['epel'] -> Package[$pip]
+          if $python::use_epel == true {
+            include 'epel'
+            Class['epel'] -> Package[$pip]
+          }
         }
         if ($venv_ensure == present) and ($::operatingsystemrelease =~ /^6/) {
-          include 'epel'
-          Class['epel'] -> Package['python-virtualenv']
+          if $python::use_epel == true {
+            include 'epel'
+            Class['epel'] -> Package['python-virtualenv']
+          }
         }
       }
       package { 'python-virtualenv': ensure => $venv_ensure }
@@ -81,5 +85,4 @@ class python::install {
     }
     package { 'gunicorn': ensure => $gunicorn_ensure }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
-
-# Class: python::params
+# == Class: python::params
+#
 # The python Module default configuration settings.
 #
 class python::params {
@@ -15,4 +15,5 @@ class python::params {
     'Debian' => ['3', '3.3'],
     'Suse'   => [],
   }
+  $use_epel               = true
 }


### PR DESCRIPTION
Without this patch, people in secure environments who are not directly
routed to the internet or who mirror their own EPEL repositories cannot
use this module as it currently mandates the usage of the epel module.
This patch makes that optional and defaults to including it, such that
it will continue to work as expected for current users.