### PR TITLE
Experimental support for SCL repositories on RHEL and CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ python::python_pips:
     virtualenv: "/opt/env2"
 ```
 
+### Using SCL packages from RedHat or CentOS
+
+To use this module with the Red Hat Software Collections (SCL) or the CentOS
+equivalents, set python::provider to 'scl' and python::version to the name of
+the collection you want to use (e.g., 'python27', 'python33', or
+'rh-python34').
+
+
 ## Authors
 
 [Sergey Stankevich](https://github.com/stankevich) | [Shiva Poudel](https://github.com/shivapoudel) | [Garrett Honeycutt](http://learnpuppet.com)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,12 +72,13 @@ class python (
 
   # validate inputs
   if $provider != undef {
-    validate_re($provider, ['^pip$'], 'Only "pip" is a valid provider besides the system default.')
+    validate_re($provider, ['^(pip|scl)$'], 'Only "pip" or "scl" are valid providers besides the system default.')
   }
 
   if $provider == 'pip' {
     validate_re($version, ['^(2\.[4-7]\.\d|3\.\d\.\d)$','^system$'])
-  # this will only be checked if not pip, every other string would be rejected by provider check
+  } elsif $provider == 'scl' {
+    validate_re($version, concat(['python33', 'python27', 'rh-python34'], $valid_versions))
   } else {
     validate_re($version, concat(['system', 'pypy'], $valid_versions))
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -88,7 +88,8 @@ class python::install {
       exec { 'python-scl-pip-install':
         require => Package['scl-utils'],
         command => "scl enable ${python::version} -- easy_install pip",
-        onlyif  => $pip_ensure,
+        path    => ["/usr/bin", "/bin"],
+        onlyif  => "test x == x${pip_ensure}",
         creates => "/opt/rh/${python::version}/root/usr/bin/pip",
       }
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -91,7 +91,7 @@ class python::install {
         command => "scl enable ${python::version} -- easy_install pip",
         path    => ["/usr/bin", "/bin"],
         onlyif  => $pip_ensure ? {
-          true    => "/bin/true",
+          present => "/bin/true",
           default => "/bin/false",
         },
         creates => "/opt/rh/${python::version}/root/usr/bin/pip",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,7 +93,7 @@ class python::install {
         onlyif  => $pip_ensure ? {
           true    => "/bin/true",
           default => "/bin/false",
-        }
+        },
         creates => "/opt/rh/${python::version}/root/usr/bin/pip",
       }
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -77,10 +77,11 @@ class python::install {
         ensure  => present,
         require => Package['scl-utils'],
       }
-      package { "${python::version}-python-virtualenv":
-        ensure  => $venv_ensure,
-        require => Package['scl-utils'],
-      }
+      # This gets installed as a dependency anyway
+      # package { "${python::version}-python-virtualenv":
+      #   ensure  => $venv_ensure,
+      #   require => Package['scl-utils'],
+      # }
       package { "${python::version}-scldev":
         ensure  => $dev_ensure,
         require => Package['scl-utils'],
@@ -89,7 +90,10 @@ class python::install {
         require => Package['scl-utils'],
         command => "scl enable ${python::version} -- easy_install pip",
         path    => ["/usr/bin", "/bin"],
-        onlyif  => "test x == x${pip_ensure}",
+        onlyif  => $pip_ensure ? {
+          true    => "/bin/true",
+          default => "/bin/false",
+        }
         creates => "/opt/rh/${python::version}/root/usr/bin/pip",
       }
     }

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -51,7 +51,6 @@ define python::pyvenv (
   $ensure           = present,
   $version          = 'system',
   $systempkgs       = false,
-  $sclname          = 'python33',
   $venv_dir         = $name,
   $owner            = 'root',
   $group            = 'root',
@@ -62,10 +61,12 @@ define python::pyvenv (
 
   if $ensure == 'present' {
 
-    $virtualenv_cmd = $version ? {
-      'system' => 'pyvenv',
-      'scl'    => "scl enable ${sclname} -- pyvenv --clear",
-      default  => "pyvenv-${version}",
+    $virtualenv_cmd = $python::provider ? {
+      'scl'   => "scl enable ${python::version} -- pyvenv --clear",
+      default => $version ? {
+        'system' => 'pyvenv',
+        default  => "pyvenv-${version}",
+      }
     }
 
     if ( $systempkgs == true ) {

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -51,6 +51,7 @@ define python::pyvenv (
   $ensure           = present,
   $version          = 'system',
   $systempkgs       = false,
+  $sclname          = 'python33',
   $venv_dir         = $name,
   $owner            = 'root',
   $group            = 'root',
@@ -63,6 +64,7 @@ define python::pyvenv (
 
     $virtualenv_cmd = $version ? {
       'system' => 'pyvenv',
+      'scl'    => "scl enable ${sclname} -- pyvenv --clear",
       default  => "pyvenv-${version}",
     }
 


### PR DESCRIPTION
This is in response to issue #189 and provides nominal support for SCL packages.  I have only had a chance to test this with CentOS 6 and the python33 collection, so please treat this as experimental and intended to be a conversation starter, not a completely finished patch.

The module appears to function nominally correctly by setting python::provider to 'scl' and python::version to 'python33' (or whatever the name of the collection is).

I'm not sure pip is doing the correct thing -- RedHat in its wisdom declined to include a pip package in the RHEL 6 SCLs.