### PR TITLE
Added rhscl provider from softwarecollections.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,9 @@ python::python_pips:
 
 ### Using SCL packages from RedHat or CentOS
 
-To use this module with the Red Hat Software Collections (SCL) or the CentOS
-equivalents, set python::provider to 'scl' and python::version to the name of
-the collection you want to use (e.g., 'python27', 'python33', or
-'rh-python34').
+To use this module with Linux distributions in the Red Hat family and python distributions
+from softwarecollections.org, set python::provider to 'rhscl' and python::version to the name 
+of the collection you want to use (e.g., 'python27', 'python33', or 'rh-python34').
 
 
 ## Authors

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class python (
 
   # validate inputs
   if $provider != undef {
-    validate_re($provider, ['^(pip|scl)$'], 'Only "pip" or "scl" are valid providers besides the system default.')
+    validate_re($provider, ['^(pip|scl|rhscl)$'], 'Only "pip", "rhscl", and "scl" are valid providers besides the system default.')
   }
 
   if $provider == 'pip' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -101,6 +101,36 @@ class python::install {
         creates => "/opt/rh/${python::version}/root/usr/bin/pip",
       }
     }
+    rhscl: {
+      # rhscl is RedHat SCLs from softwarecollections.org
+      $scl_package = "rhscl-${::python::version}-epel-${::operatingsystemmajrelease}-${::architecture}"
+      package { $scl_package:
+        source   => "https://www.softwarecollections.org/en/scls/rhscl/${::python::version}/epel-${::operatingsystemmajrelease}-${::architecture}/download/${scl_package}.noarch.rpm",
+        provider => 'rpm',
+        tag      => 'python-scl-repo',
+      }
+
+      package { $::python::version:
+        ensure => present,
+        tag    => 'python-scl-package',
+      }
+
+      package { "${python::version}-scldev":
+        ensure => $dev_ensure,
+        tag    => 'python-scl-package',
+      }
+
+      if  $pip_ensure  {
+        exec { 'python-scl-pip-install':
+          command => "${python::params::exec_prefix}easy_install pip",
+          path    => ['/usr/bin', '/bin'],
+          creates => "/opt/rh/${python::version}/root/usr/bin/pip",
+        }
+      }
+      Package <| tag == 'python-scl-repo' |> ->
+      Package <| tag == 'python-scl-package' |> ->
+      Exec['python-scl-pip-install']
+    }
     default: {
       if $::osfamily == 'RedHat' {
         if $pip_ensure == present {

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -63,6 +63,7 @@ define python::pyvenv (
 
     $virtualenv_cmd = $python::provider ? {
       'scl'   => "scl enable ${python::version} -- pyvenv --clear",
+      'rhscl'   => "scl enable ${python::version} -- pyvenv --clear",
       default => $version ? {
         'system' => 'pyvenv',
         default  => "pyvenv-${version}",


### PR DESCRIPTION
The earlier submitted "scl" provider only works for CentOS 6 unfortunately, and upon further research it looks like the CentOS team is discontinuing support for a direct-pull SCL package because of code provenance issues. 

Instead, future SCL work appears to be entirely driven through softwarecollections.org, a site almost entirely maintained and supplied by Red Hat.  I've created a different provider here called "rhscl" which will automatically pull the collection equivalent to the value of the version parameter (as in the previously submitted scl provider).