### PR TITLE
Added exec_prefix to clean up exec statements, particularly for scl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,10 +78,16 @@ class python (
 
   if $provider == 'pip' {
     validate_re($version, ['^(2\.[4-7]\.\d|3\.\d\.\d)$','^system$'])
-  } elsif $provider == 'scl' {
+  } elsif ($provider == 'scl' or $provider == 'rhscl') {
     validate_re($version, concat(['python33', 'python27', 'rh-python34'], $valid_versions))
   } else {
     validate_re($version, concat(['system', 'pypy'], $valid_versions))
+  }
+
+  $exec_prefix = $provider ? {
+    'scl'   => "scl enable ${version} -- ",
+    'rhscl' => "scl enable ${version} -- ",
+    default => '',
   }
 
   validate_bool($pip)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -88,17 +88,13 @@ class python::install {
         ensure  => $dev_ensure,
         require => Package['scl-utils'],
       }
-      # This looks absurd but I can't figure out a better way
-      $pip_exec_onlyif = $pip_ensure ? {
-          present => '/bin/true',
-          default => '/bin/false',
-      }
-      exec { 'python-scl-pip-install':
-        require => Package['scl-utils'],
-        command => "scl enable ${python::version} -- easy_install pip",
-        path    => ['/usr/bin', '/bin'],
-        onlyif  => $pip_exec_onlyif,
-        creates => "/opt/rh/${python::version}/root/usr/bin/pip",
+      if  $pip_ensure  {
+        exec { 'python-scl-pip-install':
+          require => Package['scl-utils'],
+          command => "${python::params::exec_prefix}easy_install pip",
+          path    => ['/usr/bin', '/bin'],
+          creates => "/opt/rh/${python::version}/root/usr/bin/pip",
+        }
       }
     }
     rhscl: {
@@ -122,7 +118,7 @@ class python::install {
 
       if  $pip_ensure  {
         exec { 'python-scl-pip-install':
-          command => "${python::params::exec_prefix}easy_install pip",
+          command => "${python::exec_prefix}easy_install pip",
           path    => ['/usr/bin', '/bin'],
           creates => "/opt/rh/${python::version}/root/usr/bin/pip",
         }

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -61,13 +61,9 @@ define python::pyvenv (
 
   if $ensure == 'present' {
 
-    $virtualenv_cmd = $python::provider ? {
-      'scl'   => "scl enable ${python::version} -- pyvenv --clear",
-      'rhscl'   => "scl enable ${python::version} -- pyvenv --clear",
-      default => $version ? {
-        'system' => 'pyvenv',
-        default  => "pyvenv-${version}",
-      }
+    $virtualenv_cmd = $version ? {
+      'system' => "${python::exec_prefix}pyvenv",
+      default  => "${python::exec_prefix}pyvenv-${version}",
     }
 
     if ( $systempkgs == true ) {
@@ -84,7 +80,7 @@ define python::pyvenv (
     }
 
     exec { "python_virtualenv_${venv_dir}":
-      command     => "${virtualenv_cmd} ${system_pkgs_flag} ${venv_dir}",
+      command     => "${virtualenv_cmd} --clear ${system_pkgs_flag} ${venv_dir}",
       user        => $owner,
       creates     => "${venv_dir}/bin/activate",
       path        => $path,

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -94,8 +94,8 @@ define python::requirements (
   }
 
   $pip_env = $virtualenv ? {
-    'system' => 'pip',
-    default  => "${virtualenv}/bin/pip",
+    'system' => "${python::exec_prefix} pip",
+    default  => "${python::exec_prefix} ${virtualenv}/bin/pip",
   }
 
   $proxy_flag = $proxy ? {

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -153,8 +153,10 @@ define python::virtualenv (
       mode   => $mode
     }
 
+    $pip_cmd = "${python::exec_prefix}${venv_dir}/bin/pip"
+
     exec { "python_virtualenv_${venv_dir}":
-      command     => "true ${proxy_command} && ${used_virtualenv} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
+      command     => "true ${proxy_command} && ${used_virtualenv} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${pip_cmd} wheel --help > /dev/null 2>&1 && { ${pip_cmd} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
       user        => $owner,
       creates     => "${venv_dir}/bin/activate",
       path        => $path,
@@ -167,7 +169,7 @@ define python::virtualenv (
 
     if $requirements {
       exec { "python_requirements_initial_install_${requirements}_${venv_dir}":
-        command     => "${venv_dir}/bin/pip wheel --help > /dev/null 2>&1 && { ${venv_dir}/bin/pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; ${venv_dir}/bin/pip --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag -r ${requirements} ${extra_pip_args}",
+        command     => "${pip_cmd} wheel --help > /dev/null 2>&1 && { ${pip_cmd} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag -r ${requirements} ${extra_pip_args}",
         refreshonly => true,
         timeout     => $timeout,
         user        => $owner,

--- a/spec/defines/pyvenv_spec.rb
+++ b/spec/defines/pyvenv_spec.rb
@@ -5,7 +5,7 @@ describe 'python::pyvenv', :type => :define do
 
   it {
     should contain_file( '/opt/env')
-    should contain_exec( "python_virtualenv_/opt/env").with_command("pyvenv  /opt/env")
+    should contain_exec( "python_virtualenv_/opt/env").with_command("pyvenv --clear  /opt/env")
   }
 
   describe 'when ensure' do


### PR DESCRIPTION
This is a bit of a code cleanup that benefits the SCL provider code but also centralizes the specifics of exec in several circumstances to simplify some exec statement logic. No features added, just a tidy-up.

One change of note is that pyvenv now runs with the --clear flag.  In python 3.3, if the virtual environment directory already exists, pyvenv will fail.  In python 3.4, pyvenv will assume the --clear flag.  So this clears an error without changing working behavior.