### PR TITLE
Resolve circular dep when installing gunicorn in venv

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,8 +106,8 @@ class python (
   # Anchor pattern to contain dependencies
   anchor { 'python::begin': } ->
   class { 'python::install': } ->
-  class { 'python::config': } ->
   Exec<| tag == 'python-virtualenv' |> ->
+  class { 'python::config': } ->
   anchor { 'python::end': }
 
   # Allow hiera configuration of python resources


### PR DESCRIPTION
The anchor pattern now requires python::config to happen before creating virtual envs. If gunicorn is installed in the virtual env, it can not be started before the virtual env is created. But the service is declared in python::config.

That looks something like this:
```
(Exec[python_virtualenv_/srv/venv/myenv] => Python::Virtualenv[myenv] => Python::Gunicorn[myapp] => File[/etc/gunicorn.d/myapp] => Python::Gunicorn[myapp] => Service[gunicorn] => Class[Python::Config] => Exec[python_virtualenv_/srv/venv/myenv])
```

The declaration that causes this is:
```puppet
python::virtualenv { 'myenv':
  venv_dir => '/srv/venv/myenv';
}

python::gunicorn { 'myapp':
  virtualenv => '/srv/venv/myenv',
  dir        => '/srv/myapp/',
  appmodule  => 'wsgi:app',
  require    => Python::Virtualenv['myenv'];  # <-- problem starts here!
}
```
If I don't require the `Python::Virtualenv` in my `Python::Gunicorn`, gunicorn won't be able to start.

Note that this doesn't re-introduce https://github.com/stankevich/puppet-python/issues/215, since the virtual env is still created after the packages are installed.