### PR TITLE
include python for access to exec_prefix

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -87,6 +87,7 @@ define python::virtualenv (
   $extra_pip_args   = '',
   $virtualenv       = undef
 ) {
+  include ::python
 
   if $ensure == 'present' {
     $python = $version ? {


### PR DESCRIPTION
We are in the process of switching from puppet 3.8.2 to puppet 4 and the following issue has arisen:

According to puppet scope documentation: "availability of out-of-scope variables is evaluation order dependent. You should only access out-of-scope variables if the class accessing them can guarantee that the other class is already declared, usually by explicitly declaring it with include before trying to read its variables."

This means if python::virtualenv is used without loading the class python prior and strict variables is activated, then an error is thrown that python::exec_prefix does not exist.