### PR TITLE
Add facts python2_version and python3_version

### DIFF
--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -1,9 +1,32 @@
 # Make python versions available as facts
 
+def get_python_version(executable)
+  if Facter::Util::Resolution.which(executable)
+    Facter::Util::Resolution.exec("#{executable} -V 2>&1").match(/^.*(\d+\.\d+\.\d+)$/)[1]
+  end
+end
+
 Facter.add("python_version") do
   setcode do
-    if Facter::Util::Resolution.which('python')
-      Facter::Util::Resolution.exec('python -V 2>&1').match(/^.*(\d+\.\d+\.\d+)$/)[1]
+    get_python_version 'python'
+  end
+end
+
+Facter.add("python2_version") do
+  setcode do
+    python2_version = get_python_version 'python2'
+    if python2_version.nil?
+      default_version = get_python_version 'python'
+      if !default_version.nil? and default_version.start_with?('2')
+        python2_version = default_version
+      end
     end
+    python2_version
+  end
+end
+
+Facter.add("python3_version") do
+  setcode do
+    get_python_version 'python3'
   end
 end

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -14,14 +14,12 @@ end
 
 Facter.add("python2_version") do
   setcode do
-    python2_version = get_python_version 'python2'
-    if python2_version.nil?
-      default_version = get_python_version 'python'
-      if !default_version.nil? and default_version.start_with?('2')
-        python2_version = default_version
-      end
+    default_version = get_python_version 'python'
+    if default_version.nil? or !default_version.start_with?('2')
+      get_python_version 'python2'
+    else
+      default_version
     end
-    python2_version
   end
 end
 

--- a/spec/unit/facter/python_version_spec.rb
+++ b/spec/unit/facter/python_version_spec.rb
@@ -5,26 +5,91 @@ describe Facter::Util::Fact do
     Facter.clear
   }
 
-  let(:python_version_output) { <<-EOS
+  let(:python2_version_output) { <<-EOS
 Python 2.7.9
+EOS
+  }
+  let(:python3_version_output) { <<-EOS
+Python 3.3.0
 EOS
   }
 
   describe "python_version" do
-    context 'returns python version when python present' do
+    context 'returns Python version when `python` present' do
       it do
         Facter::Util::Resolution.stubs(:exec)
         Facter::Util::Resolution.expects(:which).with("python").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python_version_output)
+        Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python2_version_output)
         Facter.value(:python_version).should == "2.7.9"
       end
     end
 
-    context 'returns nil when python not present' do
+    context 'returns nil when `python` not present' do
       it do
         Facter::Util::Resolution.stubs(:exec)
         Facter::Util::Resolution.expects(:which).with("python").returns(false)
         Facter.value(:python_version).should == nil
+      end
+    end
+
+  end
+
+  describe "python2_version" do
+    context 'returns Python 2 version when `python2` is present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python2 -V 2>&1").returns(python2_version_output)
+        Facter.value(:python2_version).should == '2.7.9'
+      end
+    end
+
+    context 'returns Python 2 version when `python2` is absent and `python` is Python 2' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
+        Facter::Util::Resolution.expects(:which).with("python").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python2_version_output)
+        Facter.value(:python2_version).should == '2.7.9'
+      end
+    end
+    
+    context 'returns nil when `python2` is absent and `python` is Python 3' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
+        Facter::Util::Resolution.expects(:which).with("python").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python3_version_output)
+        Facter.value(:python2_version).should == nil
+      end
+    end
+    
+    context 'returns nil when `python2` and `python` are absent' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python").returns(false)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
+        Facter.value(:python2_version).should == nil
+      end
+    end
+
+  end
+ 
+  describe "python3_version" do
+    context 'returns Python 3 version when `python3` present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python3").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python3 -V 2>&1").returns(python3_version_output)
+        Facter.value(:python3_version).should == "3.3.0"
+      end
+    end
+
+    context 'returns nil when `python3` not present' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python3").returns(false)
+        Facter.value(:python3_version).should == nil
       end
     end
 

--- a/spec/unit/facter/python_version_spec.rb
+++ b/spec/unit/facter/python_version_spec.rb
@@ -35,31 +35,32 @@ EOS
   end
 
   describe "python2_version" do
-    context 'returns Python 2 version when `python2` is present' do
+    context 'returns Python 2 version when `python` is present and Python 2' do
       it do
         Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with("python2").returns(true)
-        Facter::Util::Resolution.expects(:exec).with("python2 -V 2>&1").returns(python2_version_output)
-        Facter.value(:python2_version).should == '2.7.9'
-      end
-    end
-
-    context 'returns Python 2 version when `python2` is absent and `python` is Python 2' do
-      it do
-        Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
         Facter::Util::Resolution.expects(:which).with("python").returns(true)
         Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python2_version_output)
         Facter.value(:python2_version).should == '2.7.9'
       end
     end
-    
-    context 'returns nil when `python2` is absent and `python` is Python 3' do
+
+    context 'returns Python 2 version when `python` is Python 3 and `python2` is present' do
       it do
         Facter::Util::Resolution.stubs(:exec)
-        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
         Facter::Util::Resolution.expects(:which).with("python").returns(true)
         Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python3_version_output)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python2 -V 2>&1").returns(python2_version_output)
+        Facter.value(:python2_version).should == '2.7.9'
+      end
+    end
+    
+    context 'returns nil when `python` is Python 3 and `python2` is absent' do
+      it do
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Resolution.expects(:which).with("python").returns(true)
+        Facter::Util::Resolution.expects(:exec).with("python -V 2>&1").returns(python3_version_output)
+        Facter::Util::Resolution.expects(:which).with("python2").returns(false)
         Facter.value(:python2_version).should == nil
       end
     end


### PR DESCRIPTION
There currently does not appear to be a fact to get the Python versions specifically for Python 2 or Python 3. This pull request adds the necessary facts.

The python2_version fact in this PR prefers the `python` executable over `python2` if `python` is Python 2. This preference may need to be adjusted.