### PR TITLE
Check that we have results before returning a value

### DIFF
--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -2,7 +2,10 @@
 
 def get_python_version(executable)
   if Facter::Util::Resolution.which(executable)
-    Facter::Util::Resolution.exec("#{executable} -V 2>&1").match(/^.*(\d+\.\d+\.\d+)$/)[1]
+    results = Facter::Util::Resolution.exec("#{executable} -V 2>&1").match(/^.*(\d+\.\d+\.\d+)$/)
+    if results
+      results[1]
+    end
   end
 end
 


### PR DESCRIPTION
Without this change, empty results yield a message like the following in
Facter output.

  undefined method `[]' for nil:NilClass

This work captures the results and check to them to ensure we return
a valid value.