### PR TITLE
Allow custom versions to be installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@
 # Garrett Honeycutt <code@garretthoneycutt.com>
 #
 class python (
+  $ensure                    = $python::params::ensure,
   $version                   = $python::params::version,
   $pip                       = $python::params::pip,
   $dev                       = $python::params::dev,
@@ -76,23 +77,14 @@ class python (
       "Only 'pip', 'rhscl' and 'scl' are valid providers besides the system default. Detected provider is <${provider}>.")
   }
 
-  if $provider == 'pip' {
-    validate_re($version, ['^(2\.[4-7]\.\d|3\.\d\.\d)$','^system$'])
-  } elsif ($provider == 'scl' or $provider == 'rhscl') {
-    validate_re($version, concat(['python33', 'python27', 'rh-python34'], $valid_versions))
-  } else {
-    validate_re($version, concat(['system', 'pypy'], $valid_versions))
-  }
-
   $exec_prefix = $provider ? {
     'scl'   => "scl enable ${version} -- ",
     'rhscl' => "scl enable ${version} -- ",
     default => '',
   }
 
-  validate_bool($pip)
-  validate_bool($dev)
-  validate_bool($virtualenv)
+  validate_re($ensure, ['^(absent|present|latest)$'])
+  validate_re($version, concat(['system', 'pypy'], $valid_versions))
   validate_bool($gunicorn)
   validate_bool($manage_gunicorn)
   validate_bool($use_epel)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@
 # The python Module default configuration settings.
 #
 class python::params {
+  $ensure                 = 'present'
   $version                = 'system'
   $pip                    = true
   $dev                    = false

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -19,13 +19,13 @@ describe 'python', :type => :class do
     # Base debian packages.
     it { is_expected.to contain_package("python") }
     it { is_expected.to contain_package("python-dev") }
-    it { is_expected.to contain_package("python-pip") }
+    it { is_expected.to contain_package("pip") }
     # Basic python packages (from pip)
-    it { is_expected.to contain_package("python-virtualenv")}
+    it { is_expected.to contain_package("virtualenv")}
 
     describe "with python::dev" do
       context "true" do
-        let (:params) {{ :dev => true }} 
+        let (:params) {{ :dev => true }}
         it { is_expected.to contain_package("python-dev").with_ensure('present') }
       end
       context "empty/default" do
@@ -35,15 +35,15 @@ describe 'python', :type => :class do
 
     describe "with manage_gunicorn" do
       context "true" do
-        let (:params) {{ :manage_gunicorn => true }} 
+        let (:params) {{ :manage_gunicorn => true }}
         it { is_expected.to contain_package("gunicorn") }
       end
       context "empty args" do
-        #let (:params) {{ :manage_gunicorn => '' }} 
+        #let (:params) {{ :manage_gunicorn => '' }}
         it { is_expected.to contain_package("gunicorn") }
       end
       context "false" do
-        let (:params) {{ :manage_gunicorn => false }} 
+        let (:params) {{ :manage_gunicorn => false }}
         it {is_expected.not_to contain_package("gunicorn")}
       end
     end
@@ -58,29 +58,29 @@ describe 'python', :type => :class do
           'provider' => 'pip'
         )}
       end
-      
+
       # python::provider
       context "default" do
         let (:params) {{ :provider => '' }}
-        it { is_expected.to contain_package("python-virtualenv")}
-        it { is_expected.to contain_package("python-pip")}
-        
+        it { is_expected.to contain_package("virtualenv")}
+        it { is_expected.to contain_package("pip")}
+
         describe "with python::virtualenv" do
           context "true" do
             let (:params) {{ :provider => '', :virtualenv => true }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('present') }
+            it { is_expected.to contain_package("virtualenv").with_ensure('present') }
           end
         end
-        
+
         describe "without python::virtualenv" do
           context "default/empty" do
             let (:params) {{ :provider => '' }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('absent') }
+            it { is_expected.to contain_package("virtualenv").with_ensure('absent') }
           end
         end
       end
     end
-    
+
     describe "with python::dev" do
       context "true" do
         let (:params) {{ :dev => true }}
@@ -91,7 +91,7 @@ describe 'python', :type => :class do
       end
     end
   end
-  
+
   context "on a Redhat 5 OS" do
     let :facts do
       {
@@ -107,108 +107,18 @@ describe 'python', :type => :class do
     it { is_expected.to contain_class("python::install") }
     # Base debian packages.
     it { is_expected.to contain_package("python") }
-    it { is_expected.to contain_package("python-devel") }
-    it { is_expected.to contain_package("python-pip") }
+    it { is_expected.to contain_package("python-dev").with_name("python-devel") }
+    it { is_expected.to contain_package("pip") }
     # Basic python packages (from pip)
-    it { is_expected.to contain_package("python-virtualenv")}
-  
-    describe "with python::dev" do
-      context "true" do
-        let (:params) {{ :dev => true }}
-        it { is_expected.to contain_package("python-devel").with_ensure('present') }
-      end
-      context "empty/default" do
-        it { is_expected.to contain_package("python-devel").with_ensure('absent') }
-      end
-    end
-    
-    describe "with manage_gunicorn" do
-      context "true" do
-        let (:params) {{ :manage_gunicorn => true }} 
-        it { is_expected.to contain_package("gunicorn") }
-      end
-      context "empty args" do
-        #let (:params) {{ :manage_gunicorn => '' }} 
-        it { is_expected.to contain_package("gunicorn") }
-      end
-      context "false" do
-        let (:params) {{ :manage_gunicorn => false }} 
-        it {is_expected.not_to contain_package("gunicorn")}
-      end
-    end
-
-    describe "with python::provider" do
-      context "pip" do
-        let (:params) {{ :provider => 'pip' }}
-
-        it { is_expected.to contain_package("virtualenv").with(
-          'provider' => 'pip'
-        )}
-        it { is_expected.to contain_package("pip").with(
-          'provider' => 'pip'
-        )}
-      end
-      
-      # python::provider
-      context "default" do
-        let (:params) {{ :provider => '' }} 
-        it { is_expected.to contain_package("python-virtualenv")}
-        it { is_expected.to contain_package("python-pip")}
-        
-        describe "with python::virtualenv" do
-          context "true" do
-            let (:params) {{ :provider => '', :virtualenv => true }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('present') }
-          end
-        end
-        
-        describe "with python::virtualenv" do
-          context "default/empty" do
-            let (:params) {{ :provider => '' }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('absent') }
-          end
-        end
-      end
-    end
-    
-    describe "with python::dev" do
-      context "true" do
-        let (:params) {{ :dev => true }} 
-        it { is_expected.to contain_package("python-devel").with_ensure('present') }
-      end
-      context "default/empty" do
-        it { is_expected.to contain_package("python-devel").with_ensure('absent') }
-      end
-    end
-  end
-
-  context "on a SLES 11 SP3" do
-    let :facts do
-      {
-        :id => 'root',
-        :kernel => 'Linux',
-        :osfamily => 'Suse',
-        :operatingsystem => 'SLES',
-        :operatingsystemrelease => '11.3',
-        :concat_basedir => '/dne',
-        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
-    end
-    it { is_expected.to contain_class("python::install") }
-    # Base Suse packages.
-    it { is_expected.to contain_package("python") }
-    it { is_expected.to contain_package("python-devel") }
-    it { is_expected.to contain_package("python-pip") }
-    # Basic python packages (from pip)
-    it { is_expected.to contain_package("python-virtualenv")}
+    it { is_expected.to contain_package("virtualenv")}
 
     describe "with python::dev" do
       context "true" do
         let (:params) {{ :dev => true }}
-        it { is_expected.to contain_package("python-devel").with_ensure('present') }
+        it { is_expected.to contain_package("python-dev").with_ensure('present') }
       end
       context "empty/default" do
-        it { is_expected.to contain_package("python-devel").with_ensure('absent') }
+        it { is_expected.to contain_package("python-dev").with_ensure('absent') }
       end
     end
 
@@ -242,20 +152,20 @@ describe 'python', :type => :class do
       # python::provider
       context "default" do
         let (:params) {{ :provider => '' }}
-        it { is_expected.to contain_package("python-virtualenv")}
-        it { is_expected.to contain_package("python-pip")}
+        it { is_expected.to contain_package("virtualenv")}
+        it { is_expected.to contain_package("pip")}
 
         describe "with python::virtualenv" do
           context "true" do
             let (:params) {{ :provider => '', :virtualenv => true }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('present') }
+            it { is_expected.to contain_package("virtualenv").with_ensure('present') }
           end
         end
 
         describe "with python::virtualenv" do
           context "default/empty" do
             let (:params) {{ :provider => '' }}
-            it { is_expected.to contain_package("python-virtualenv").with_ensure('absent') }
+            it { is_expected.to contain_package("virtualenv").with_ensure('absent') }
           end
         end
       end
@@ -264,10 +174,100 @@ describe 'python', :type => :class do
     describe "with python::dev" do
       context "true" do
         let (:params) {{ :dev => true }}
-        it { is_expected.to contain_package("python-devel").with_ensure('present') }
+        it { is_expected.to contain_package("python-dev").with_ensure('present') }
       end
       context "default/empty" do
-        it { is_expected.to contain_package("python-devel").with_ensure('absent') }
+        it { is_expected.to contain_package("python-dev").with_ensure('absent') }
+      end
+    end
+  end
+
+  context "on a SLES 11 SP3" do
+    let :facts do
+      {
+        :id => 'root',
+        :kernel => 'Linux',
+        :osfamily => 'Suse',
+        :operatingsystem => 'SLES',
+        :operatingsystemrelease => '11.3',
+        :concat_basedir => '/dne',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it { is_expected.to contain_class("python::install") }
+    # Base Suse packages.
+    it { is_expected.to contain_package("python") }
+    it { is_expected.to contain_package("python-dev").with_name("python-devel") }
+    it { is_expected.to contain_package("pip") }
+    # Basic python packages (from pip)
+    it { is_expected.to contain_package("virtualenv")}
+
+    describe "with python::dev" do
+      context "true" do
+        let (:params) {{ :dev => true }}
+        it { is_expected.to contain_package("python-dev").with_ensure('present') }
+      end
+      context "empty/default" do
+        it { is_expected.to contain_package("python-dev").with_ensure('absent') }
+      end
+    end
+
+    describe "with manage_gunicorn" do
+      context "true" do
+        let (:params) {{ :manage_gunicorn => true }}
+        it { is_expected.to contain_package("gunicorn") }
+      end
+      context "empty args" do
+        #let (:params) {{ :manage_gunicorn => '' }}
+        it { is_expected.to contain_package("gunicorn") }
+      end
+      context "false" do
+        let (:params) {{ :manage_gunicorn => false }}
+        it {is_expected.not_to contain_package("gunicorn")}
+      end
+    end
+
+    describe "with python::provider" do
+      context "pip" do
+        let (:params) {{ :provider => 'pip' }}
+
+        it { is_expected.to contain_package("virtualenv").with(
+          'provider' => 'pip'
+        )}
+        it { is_expected.to contain_package("pip").with(
+          'provider' => 'pip'
+        )}
+      end
+
+      # python::provider
+      context "default" do
+        let (:params) {{ :provider => '' }}
+        it { is_expected.to contain_package("virtualenv")}
+        it { is_expected.to contain_package("pip")}
+
+        describe "with python::virtualenv" do
+          context "true" do
+            let (:params) {{ :provider => '', :virtualenv => true }}
+            it { is_expected.to contain_package("virtualenv").with_ensure('present') }
+          end
+        end
+
+        describe "with python::virtualenv" do
+          context "default/empty" do
+            let (:params) {{ :provider => '' }}
+            it { is_expected.to contain_package("virtualenv").with_ensure('absent') }
+          end
+        end
+      end
+    end
+
+    describe "with python::dev" do
+      context "true" do
+        let (:params) {{ :dev => true }}
+        it { is_expected.to contain_package("python-dev").with_ensure('present') }
+      end
+      context "default/empty" do
+        it { is_expected.to contain_package("python-dev").with_ensure('absent') }
       end
     end
   end


### PR DESCRIPTION
Fixes #240. Allow the `ensure` parameter to be specified of `python::pip` and `python::virtualenv`.

This is a bit rough... let me know if you are interested in this change and I will tidy it up.