### PR TITLE
Fix an issue with gunicorn

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,7 +22,7 @@ class python::config {
   Python::Virtualenv <| |> -> Python::Pip <| |>
 
   if $python::manage_gunicorn {
-    if $python::gunicorn {
+    if $python::gunicorn != 'absent' {
       Class['python::install'] -> Python::Gunicorn <| |>
 
       Python::Gunicorn <| |> ~> Service['gunicorn']


### PR DESCRIPTION
Fixes the following error:

```
err: /Stage[main]/Python::Config/Service[gunicorn]/ensure: change from stopped to running failed: Could not find init script for 'gunicorn'
```