### PR TITLE
Allow setting a custom index for `python::pip`

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -60,7 +60,7 @@
 #   requirements => '/var/www/project1/requirements.txt',
 #   proxy        => 'http://proxy.domain.com:3128',
 #   systempkgs   => true,
-#   index        => 'http://www.example.com/simple/'
+#   index        => 'http://www.example.com/simple/',
 # }
 #
 # === Authors

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -43,12 +43,27 @@ describe 'python::pip', :type => :define do
       end
       context "adds proxy to install command if proxy set" do
         let (:params) {{ :proxy => "http://my.proxy:3128" }}
-        it { is_expected.to contain_exec("pip_install_rpyc").with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install $wheel_support_flag --proxy=http://my.proxy:3128   rpyc || pip --log /tmp/pip.log install --proxy=http://my.proxy:3128   rpyc ;}") }
+        it { is_expected.to contain_exec("pip_install_rpyc").with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install $wheel_support_flag  --proxy=http://my.proxy:3128   rpyc || pip --log /tmp/pip.log install  --proxy=http://my.proxy:3128   rpyc ;}") }
       end
       context "adds proxy to search command if set to latest" do
         let (:params) {{ :proxy => "http://my.proxy:3128", :ensure => 'latest' }}
-        it { is_expected.to contain_exec("pip_install_rpyc").with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install --upgrade $wheel_support_flag --proxy=http://my.proxy:3128   rpyc || pip --log /tmp/pip.log install --upgrade --proxy=http://my.proxy:3128   rpyc ;}") }
+        it { is_expected.to contain_exec("pip_install_rpyc").with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install --upgrade $wheel_support_flag  --proxy=http://my.proxy:3128   rpyc || pip --log /tmp/pip.log install --upgrade  --proxy=http://my.proxy:3128   rpyc ;}") }
         it { is_expected.to contain_exec("pip_install_rpyc").with_unless('pip search --proxy=http://my.proxy:3128 rpyc | grep -i INSTALLED | grep -i latest') }
+      end
+    end
+
+    describe 'index as' do
+      context 'defaults to empty' do
+        let (:params) {{ }}
+        it { is_expected.to contain_exec('pip_install_rpyc').without_command(/--index-url/) }
+      end
+      context 'adds index to install command if index set' do
+        let (:params) {{ :index => 'http://www.example.com/simple/' }}
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install $wheel_support_flag --index-url=http://www.example.com/simple/    rpyc || pip --log /tmp/pip.log install --index-url=http://www.example.com/simple/    rpyc ;}") }
+      end
+      context 'adds index to search command if set to latest' do
+        let (:params) {{ :index => 'http://www.example.com/simple/', :ensure => 'latest' }}
+        it { is_expected.to contain_exec('pip_install_rpyc').with_command("pip wheel --help > /dev/null 2>&1 && { pip wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { pip --log /tmp/pip.log install --upgrade $wheel_support_flag --index-url=http://www.example.com/simple/    rpyc || pip --log /tmp/pip.log install --upgrade --index-url=http://www.example.com/simple/    rpyc ;}") }
       end
     end
 


### PR DESCRIPTION
Currently it is possible to pass `--index-url=${index}` to `python::virtualenv` but not to `python::pip`.