### PR TITLE
Fix pip git repo install every puppet run

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -134,18 +134,14 @@ define python::pip (
     fail('python::pip cannot provide uninstall_args with ensure => present')
   }
 
-  # Check if searching by explicit version.
-  if $ensure =~ /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/ {
-    if $url != false {
-      $grep_regex = $url
-    } else {
-        $grep_regex = "^${pkgname}==${ensure}\$"
-    }
+  if $url != false {
+    $grep_regex = $url
   } else {
-    if $url != false {
-      $grep_regex = $url
+    # Check if searching by explicit version.
+    if $ensure =~ /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/ {
+      $grep_regex = "^${pkgname}==${ensure}\$"
     } else {
-        $grep_regex = $pkgname ? {
+      $grep_regex = $pkgname ? {
         /==/    => "^${pkgname}\$",
         default => "^${pkgname}==",
       }

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -126,11 +126,19 @@ define python::pip (
 
   # Check if searching by explicit version.
   if $ensure =~ /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/ {
-    $grep_regex = "^${pkgname}==${ensure}\$"
+    if $url != false {
+      $grep_regex = $url
+    } else {
+        $grep_regex = "^${pkgname}==${ensure}\$"
+    }
   } else {
-    $grep_regex = $pkgname ? {
-      /==/    => "^${pkgname}\$",
-      default => "^${pkgname}==",
+    if $url != false {
+      $grep_regex = $url
+    } else {
+        $grep_regex = $pkgname ? {
+        /==/    => "^${pkgname}\$",
+        default => "^${pkgname}==",
+      }
     }
   }
 

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -67,5 +67,15 @@ describe 'python::pip', :type => :define do
       end
     end
 
+    describe 'pip install unless' do
+      context 'with url' do
+        let (:params) {{ :url => 'https://www.example.com/module.git'}}
+        it { is_expected.to contain_exec("pip_install_rpyc").with_unless(/https:\/\/www\.example\.com\/module\.git/) }
+      end
+      context 'without url' do
+        it { is_expected.to contain_exec("pip_install_rpyc").with_unless(/rpyc/) }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I think it's a valid proposal to fix that bug since url seems to always be present when doing a pip freeze. 