### PR TITLE
use full path on commands

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,8 +69,8 @@ class python::install {
     pip: {
       # Install pip without pip, see https://pip.pypa.io/en/stable/installing/.
       exec { 'bootstrap pip':
-        command => 'curl https://bootstrap.pypa.io/get-pip.py | python',
-        unless  => 'which pip',
+        command => '/usr/bin/curl https://bootstrap.pypa.io/get-pip.py | python',
+        unless  => '/usr/bin/which pip',
         require => Package['python'],
       }
       Exec['bootstrap pip'] -> Package <| provider == pip |>


### PR DESCRIPTION
On a RHEL7 host, this module fails to install pip with the following Hiera settings:
```
python::pip: present
python::provider: 'pip'
python::use_epel: false
```
The errors are:
```
==> g2: Error: Parameter unless failed on Exec[bootstrap pip]: 'which pip' is not qualified and no path was specified. Please qualify the command or specify a path. at /tmp/vagrant-puppet/modules-748e6aae0e9d5fc067b3ca7dd8f9d74d/python/manifests/install.pp:75
```
and
```
==> g2: Error: Validation of Exec[bootstrap pip] failed: 'curl https://bootstrap.pypa.io/get-pip.py | python' is not qualified and no path was specified. Please qualify the command or specify a path. at /tmp/vagrant-puppet/modules-748e6aae0e9d5fc067b3ca7dd8f9d74d/python/manifests/install.pp:75
```

This PR simply puts the full path to the executables, which resolves the errors.