### PR TITLE
Create symlink for pip-python with pip provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -73,7 +73,16 @@ class python::install {
         unless  => '/usr/bin/which pip',
         require => Package['python'],
       }
-      Exec['bootstrap pip'] -> Package <| provider == pip |>
+
+      # Puppet is opinionated about the pip command name
+      file { 'pip-python':
+        ensure  => link,
+        path    => '/usr/bin/pip-python',
+        target  => '/usr/bin/pip',
+        require => Exec['bootstrap pip'],
+      }
+
+      Exec['bootstrap pip'] -> File['pip-python'] -> Package <| provider == pip |>
 
       Package <| title == 'pip' |> {
         name     => 'pip',


### PR DESCRIPTION
Puppet is opinionated about the name of the `pip` binary.

Closes https://github.com/stankevich/puppet-python/issues/225