### PR TITLE
RedHat has different virtualenv packages for different pythons

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -174,17 +174,19 @@ class python::install {
             Class['epel'] -> Package['virtualenv']
           }
         }
+
+        $virtualenv_package = "${python}-virtualenv"
+      } else {
+        $virtualenv_package = $::lsbdistcodename ? {
+          'jessie' => 'virtualenv',
+          default  => 'python-virtualenv',
+        }
       }
 
       if $::python::version =~ /^3/ {
         $pip_package = 'python3-pip'
       } else {
         $pip_package = 'python-pip'
-      }
-
-      $virtualenv_package = $::lsbdistcodename ? {
-        'jessie' => 'virtualenv',
-        default  => 'python-virtualenv',
       }
 
       Package <| title == 'pip' |> {


### PR DESCRIPTION
For example, 'python27' can have a 'python27-virtualenv' package.