### PR TITLE
Bug virtualenv instead of virtualenv-$version

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -97,10 +97,7 @@ define python::virtualenv (
     }
 
     if $virtualenv == undef {
-      $used_virtualenv = $version ? {
-        'system' => 'virtualenv',
-        default  => "virtualenv-${version}",
-      }
+      $used_virtualenv = 'virtualenv'
     } else {
       $used_virtualenv = $virtualenv
     }


### PR DESCRIPTION
Hello,

Thank you for your useful Puppet module!

This pull request solves an error caused by the class "python::virtualenv", when the parameter "version" is changed (if you put something else than "system" in the parameter "version", "virtualenv-$version" is used instead of "virtualenv").

The error:
```
	Error: sh: 1: virtualenv-2: not found
	sh: 1: /opt/pyenv2/bin/pip: not found
	sh: 1: /opt/pyenv2/bin/pip: not found
	Error: /Stage[main]/Profiles::Python/Python::Virtualenv[pyenv2]/Exec[python_virtualenv_/opt/pyenv2]/returns: change from notrun to 0 failed: sh: 1: virtualenv-2: not found
	sh: 1: /opt/pyenv2/bin/pip: not found
	sh: 1: /opt/pyenv2/bin/pip: not found
```

My operating system: Ubuntu Wily

My Puppet code:
```
  python::virtualenv { 'pyenv2' :
    ensure       => present,
    version      => '2',
    venv_dir     => '/opt/pyenv2',
    cwd          => '/opt/pyenv2',
    timeout      => 0,
  }
```

Best regards, 

Asher256