### PR TITLE
Please fix support of Red Hat Software Collection versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class python::params {
   $manage_gunicorn        = true
   $provider               = undef
   $valid_versions = $::osfamily ? {
-    'RedHat' => ['3','27','33',  'python27', 'python33', 'rh-python34'],
+    'RedHat' => ['3','27','33', 'python27', 'python33', 'rh-python34'],
     'Debian' => ['3', '3.3', '2.7'],
     'Suse'   => [],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class python::params {
   $manage_gunicorn        = true
   $provider               = undef
   $valid_versions = $::osfamily ? {
-    'RedHat' => ['3','27','33'],
+    'RedHat' => ['3','27','33',  'python27', 'python33', 'rh-python34'],
     'Debian' => ['3', '3.3', '2.7'],
     'Suse'   => [],
   }


### PR DESCRIPTION
Support of  Red Hat Software Collection was broken with validation of python::version variable. 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: validate_re(): "python27" does not match ["system", "pypy", "3"] at .... /modules/python/manifests/init.pp:98 on node [NODE]
```
This pull request fixes this issue. 