### PR TITLE
add configurable log level for gunicorn and unit tests

### DIFF
--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -80,6 +80,7 @@ define python::gunicorn (
   $access_log_format = false,
   $accesslog         = false,
   $errorlog          = false,
+  $loglevel          = 'error',
   $template          = 'python/gunicorn.erb',
 ) {
 
@@ -87,6 +88,8 @@ define python::gunicorn (
   if ! $dir {
     fail('python::gunicorn: dir parameter must not be empty')
   }
+
+  validate_re($loglevel, 'debug|info|warning|error|critical', "Invalid \$loglevel value ${loglevel}")
 
   file { "/etc/gunicorn.d/${name}":
     ensure  => $ensure,

--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -80,7 +80,7 @@ define python::gunicorn (
   $access_log_format = false,
   $accesslog         = false,
   $errorlog          = false,
-  $loglevel          = 'error',
+  $log_level          = 'error',
   $template          = 'python/gunicorn.erb',
 ) {
 
@@ -89,7 +89,7 @@ define python::gunicorn (
     fail('python::gunicorn: dir parameter must not be empty')
   }
 
-  validate_re($loglevel, 'debug|info|warning|error|critical', "Invalid \$loglevel value ${loglevel}")
+  validate_re($log_level, 'debug|info|warning|error|critical', "Invalid \$log_level value ${log_level}")
 
   file { "/etc/gunicorn.d/${name}":
     ensure  => $ensure,

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
-describe 'python::gunicorn', type: :define do
+describe 'python::gunicorn', :type => :define do
   let(:title) { 'test-app' }
   context 'on Debian OS' do
     let :facts do
       {
-        id:                      'root',
-        kernel:                  'Linux',
-        lsbdistcodename:         'squeeze',
-        osfamily:                'Debian',
-        operatingsystem:         'Debian',
-        operatingsystemrelease:  '6',
-        path:                    '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        concat_basedir:          '/dne'
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :lsbdistcodename        => 'squeeze',
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
+        :operatingsystemrelease => '6',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :concat_basedir         => '/dne',
       }
     end
 
-    describe 'gunicorn as' do
+    describe 'test-app with default parameter values' do
       context 'configures test app with default parameter values' do
-        let(:params) { { dir: '/srv/testapp' } }
+        let(:params) { { :dir => '/srv/testapp' } }
         it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--log-level=error/) }
       end
 
-      context 'configures test app with custom log level' do
-        let(:params) { { dir: '/srv/testapp', loglevel: 'info' } }
+      context 'test-app with custom log level' do
+        let(:params) { { :dir => '/srv/testapp', :log_level => 'info' } }
         it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--log-level=info/) }
       end
     end

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'python::gunicorn', type: :define do
+  let(:title) { 'test-app' }
+  context 'on Debian OS' do
+    let :facts do
+      {
+        id:                      'root',
+        kernel:                  'Linux',
+        lsbdistcodename:         'squeeze',
+        osfamily:                'Debian',
+        operatingsystem:         'Debian',
+        operatingsystemrelease:  '6',
+        path:                    '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        concat_basedir:          '/dne'
+      }
+    end
+
+    describe 'gunicorn as' do
+      context 'configures test app with default parameter values' do
+        let(:params) { { dir: '/srv/testapp' } }
+        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--log-level=error/) }
+      end
+
+      context 'configures test app with custom log level' do
+        let(:params) { { dir: '/srv/testapp', loglevel: 'info' } }
+        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--log-level=info/) }
+      end
+    end
+  end
+end

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -42,8 +42,8 @@ CONFIG = {
 <% if @errorlog -%>
     '--error-logfile=<%= @errorlog %>',
 <% end -%>
-<% if @loglevel %>
-    '--log-level=<%= @loglevel %>',
+<% if @log_level %>
+    '--log-level=<%= @log_level %>',
 <% end -%>
 <% if @mode != 'django' -%>
     '<%= @appmodule %>',

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -42,6 +42,9 @@ CONFIG = {
 <% if @errorlog -%>
     '--error-logfile=<%= @errorlog %>',
 <% end -%>
+<% if @loglevel %>
+    '--log-level=<%= @loglevel %>',
+<% end -%>
 <% if @mode != 'django' -%>
     '<%= @appmodule %>',
 <% end -%>


### PR DESCRIPTION
log level setting for gunicorn virtual hosts, default is error

comes with basic unit test