### PR TITLE
Add parameter path to pip manifest

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -35,18 +35,16 @@
 #  Boolean. If true the package is installed as an editable resource.
 #
 # [*environment*]
-#  Additional environment variables required to install the packages.
-#  Default: none
+#  Additional environment variables required to install the packages. Default: none
 #
 # [*timeout*]
-#  The maximum time in seconds the "pip install" command should take. 
-#  Default: 1800
+#  The maximum time in seconds the "pip install" command should take. Default: 1800
 #
 # [*install_args*]
 #  String. Any additional installation arguments that will be supplied
 #  when running pip install.
 #
-# [*uninstall args*]
+# [*uninstall_args*]
 # String. Any additional arguments that will be supplied when running
 # pip uninstall.
 #
@@ -82,10 +80,9 @@ define python::pip (
   $uninstall_args  = '',
   $timeout         = 1800,
   $log_dir         = '/tmp',
+  $path            = ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
 ) {
 
-  $pip_freeze_pkgname = regsubst($pkgname, '_', '-', 'G')
-  notice("Pip freeze pkgname: ${pip_freeze_pkgname}")
   # Parameter validation
   if ! $virtualenv {
     fail('python::pip: virtualenv parameter must not be empty')
@@ -139,12 +136,12 @@ define python::pip (
   }
 
   # Check if searching by explicit version.
-  if $ensure =~ /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/ { #lint:ignore:80chars
-    $grep_regex = "^${pip_freeze_pkgname}==${ensure}\$"
+  if $ensure =~ /^((19|20)[0-9][0-9]-(0[1-9]|1[1-2])-([0-2][1-9]|3[0-1])|[0-9]+\.[0-9]+(\.[0-9]+)?)$/ {
+    $grep_regex = "^${pkgname}==${ensure}\$"
   } else {
-    $grep_regex = $pip_freeze_pkgname ? {
-      /==/    => "^${pip_freeze_pkgname}\$",
-      default => "^${pip_freeze_pkgname}==",
+    $grep_regex = $pkgname ? {
+      /==/    => "^${pkgname}\$",
+      default => "^${pkgname}==",
     }
   }
 
@@ -184,8 +181,8 @@ define python::pip (
         group       => $group,
         cwd         => $cwd,
         environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
         timeout     => $timeout,
+        path        => $path,
       }
     } else {
       exec { "pip_install_${name}":
@@ -195,8 +192,8 @@ define python::pip (
         group       => $group,
         cwd         => $cwd,
         environment => $environment,
-        path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
         timeout     => $timeout,
+        path        => $path,
       }
     }
   } else {
@@ -211,8 +208,8 @@ define python::pip (
           group       => $group,
           cwd         => $cwd,
           environment => $environment,
-          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
           timeout     => $timeout,
+          path        => $path,
         }
       }
 
@@ -225,8 +222,8 @@ define python::pip (
           group       => $group,
           cwd         => $cwd,
           environment => $environment,
-          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
           timeout     => $timeout,
+          path        => $path,
         }
       }
 
@@ -239,8 +236,8 @@ define python::pip (
           group       => $group,
           cwd         => $cwd,
           environment => $environment,
-          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
           timeout     => $timeout,
+          path        => $path,
         }
       }
 
@@ -253,8 +250,8 @@ define python::pip (
           group       => $group,
           cwd         => $cwd,
           environment => $environment,
-          path        => ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
           timeout     => $timeout,
+          path        => $path,
         }
       }
     }


### PR DESCRIPTION
In order to be able to specify a custom path for the pip exec block only, a path
parameter has been added to the pip manifest. The default value has
been added to the parameter declaration to make this change backwards
compatible.