### PR TITLE
Made virtualenv compatible with RHSCL/SCL

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -151,10 +151,11 @@ define python::virtualenv (
       mode   => $mode
     }
 
+    $virtualenv_cmd = "${python::exec_prefix}${used_virtualenv}"
     $pip_cmd = "${python::exec_prefix}${venv_dir}/bin/pip"
 
     exec { "python_virtualenv_${venv_dir}":
-      command     => "true ${proxy_command} && ${used_virtualenv} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${pip_cmd} wheel --help > /dev/null 2>&1 && { ${pip_cmd} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
+      command     => "true ${proxy_command} && ${virtualenv_cmd} ${system_pkgs_flag} -p ${python} ${venv_dir} && ${pip_cmd} wheel --help > /dev/null 2>&1 && { ${pip_cmd} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag} \$wheel_support_flag --upgrade pip ${distribute_pkg} || ${pip_cmd} --log ${venv_dir}/pip.log install ${pypi_index} ${proxy_flag}  --upgrade pip ${distribute_pkg} ;}",
       user        => $owner,
       creates     => "${venv_dir}/bin/activate",
       path        => $path,


### PR DESCRIPTION
Hi guys,

Upon trying to use this module in EL7 (CentOS) with the rh-python34 SC from softwarecollections.org, I found that the module was trying to call 'virtualenv' without the exec_prefix that is required when using Python from these sources.

I've implemented a similar fix to what was undertaken for pip, and as such this shouldn't break anything at all.

Cheers,

Chris