### PR TITLE
add SCL specific exec_prefix

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -83,6 +83,17 @@ define python::pip (
   $path            = ['/usr/local/bin','/usr/bin','/bin', '/usr/sbin'],
 ) {
 
+  $python_provider = getparam(Class['python'], 'provider')
+  $python_version  = getparam(Class['python'], 'version')
+  
+  # Get SCL exec prefix
+  # NB: this will not work if you are running puppet from scl enabled shell
+  $exec_prefix = $python_provider ? {
+    'scl'   => "scl enable ${python_version} -- ",
+    'rhscl' => "scl enable ${python_version} -- ",
+    default => '',
+  }
+  
   # Parameter validation
   if ! $virtualenv {
     fail('python::pip: virtualenv parameter must not be empty')
@@ -105,7 +116,7 @@ define python::pip (
   }
 
   $pip_env = $virtualenv ? {
-    'system' => 'pip',
+    'system' => "${exec_prefix}pip",
     default  => "${virtualenv}/bin/pip",
   }
 


### PR DESCRIPTION

When using SCL, all commands related to a particular version of python should be prefixed with "scl enable ...", including PIP. 

Before this fix pip moduler used "pip" of system python and not the pip installed/configured by python class. 

