### PR TITLE
Fixes #256

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -71,7 +71,7 @@ class python::install {
       # Install pip without pip, see https://pip.pypa.io/en/stable/installing/.
       exec { 'bootstrap pip':
         command => '/usr/bin/curl https://bootstrap.pypa.io/get-pip.py | python',
-        unless  => '/usr/bin/which pip',
+        creates => '/usr/local/bin/pip',
         require => Package['python'],
       }
 


### PR DESCRIPTION
`/usr/bin/which pip` always return `false` because `$PATH` is not set. Instead, check for existance of `/usr/local/bin/pip`.