### PR TITLE
Configure workers

### DIFF
--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -77,6 +77,7 @@ define python::gunicorn (
   $appmodule         = 'app:app',
   $osenv             = false,
   $timeout           = 30,
+  $workers           = false,
   $access_log_format = false,
   $accesslog         = false,
   $errorlog          = false,

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -31,7 +31,11 @@ CONFIG = {
 <% else -%>
     '--bind=<%= @bind %>',
 <% end -%>
-    '--workers=<%= @processorcount.to_i*2 %>',
+<% if @workers -%>
+    '--workers=<%= @workers %>'
+<% else -%>
+    '--workers=<%= @processorcount.to_i*2 + 1 %>',
+<% end -%>
     '--timeout=<%= @timeout %>',
 <% if @access_log_format -%>
     '--access-logformat=<%= @access_log_format %>',


### PR DESCRIPTION
Added ability to override the default number of gunicorn workers
as well as updated the default to match the gunicorn documentation:

(2 * num_cores) + 1

Source: http://docs.gunicorn.org/en/stable/design.html#how-many-workers