### PR TITLE
Fixed missing comma in #301

### DIFF
--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -32,7 +32,7 @@ CONFIG = {
     '--bind=<%= @bind %>',
 <% end -%>
 <% if @workers -%>
-    '--workers=<%= @workers %>'
+    '--workers=<%= @workers %>',
 <% else -%>
     '--workers=<%= @processorcount.to_i*2 + 1 %>',
 <% end -%>


### PR DESCRIPTION
Fixed missing comma in PR #301 when `workers` specified