### PR TITLE
Lowercase package name for centos-release-scl

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -103,7 +103,7 @@ class python::install {
         default  => 'absent',
       }
 
-      package { 'centos-release-SCL':
+      package { 'centos-release-scl':
         ensure => $install_scl_repo_package,
         before => Package['scl-utils'],
       }


### PR DESCRIPTION
Currently when running on CentOS7, the package centos-release-SCL is not available, and instead is called centos-release-scl.  This change corrects the capitalization for the package name.