### PR TITLE
Set gunicorn package name on RedHat family

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class python (
   $virtualenv                = $python::params::virtualenv,
   $gunicorn                  = $python::params::gunicorn,
   $manage_gunicorn           = $python::params::manage_gunicorn,
+  $gunicorn_package_name     = $python::params::gunicorn_package_name,
   $provider                  = $python::params::provider,
   $valid_versions            = $python::params::valid_versions,
   $python_pips               = { },

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -219,6 +219,7 @@ class python::install {
     }
 
     package { 'gunicorn':
+      name   => $python::gunicorn_package_name,
       ensure => $gunicorn_ensure,
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,4 +17,10 @@ class python::params {
     'Suse'   => [],
   }
   $use_epel               = true
+
+  $gunicorn_package_name = $::osfamily ? {
+    'RedHat' => 'python-gunicorn',
+    default  => 'gunicorn',
+  }
+
 }


### PR DESCRIPTION
On centos6, package name from epel is `python-gunicorn`

```
Name        : python-gunicorn
Arch        : noarch
Version     : 18.0
Release     : 1.el6
Size        : 175 k
Repo        : epel
Summary     : Python WSGI application server
URL         : http://gunicorn.org/
License     : MIT
Description : Gunicorn ("Green Unicorn") is a Python WSGI HTTP server for UNIX. It uses the
            : pre-fork worker model, ported from Ruby's Unicorn project. It supports WSGI,
            : Django, and Paster applications.
```

On centos 7, package name from extra is also `python-gunicorn`
```
Name        : python-gunicorn
Arch        : noarch
Version     : 18.0
Release     : 2.el7
Size        : 171 k
Repo        : extras/7/x86_64
Summary     : Python WSGI application server
URL         : http://gunicorn.org/
License     : MIT
Description : Gunicorn ("Green Unicorn") is a Python WSGI HTTP server for UNIX. It uses the
            : pre-fork worker model, ported from Ruby's Unicorn project. It supports WSGI,
            : Django, and Paster applications.
```

I have not found a gunicorn package in `epel` for centos5 on https://dl.fedoraproject.org/pub/epel/5