### PR TITLE
Patch to support Centos 7 in bootstrap

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -71,7 +71,8 @@ class python::install {
       # Install pip without pip, see https://pip.pypa.io/en/stable/installing/.
       exec { 'bootstrap pip':
         command => '/usr/bin/curl https://bootstrap.pypa.io/get-pip.py | python',
-        creates => '/usr/local/bin/pip',
+        unless  => 'which pip',
+        path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
         require => Package['python'],
       }
 


### PR DESCRIPTION
Fixes Centos 7 Bootstrap loop, Issue #306 

Bootstrapping currently repeats on every run due to the `creates => '/usr/local/bin/pip'`
Centos 7(and possibly others) which place pip executable in /usr/bin/pip
The repeated bootstrap needs to be patched to avoid nodes constantly grabbing the get_pip.py which includes a binary blob.

This patching looks to have been attempted before but failed to include `path => ....` which would support finding `which` in any of those locations as well as allowing `which pip` to only look in the supplied path, basically extending our creates to support multiple locations of pip.