### PR TITLE
Add "args" option to gunicorn config

### DIFF
--- a/manifests/gunicorn.pp
+++ b/manifests/gunicorn.pp
@@ -42,6 +42,9 @@
 # [*template*]
 #  Which ERB template to use. Default: python/gunicorn.erb
 #
+# [*args*]
+#  Custom arguments to add in gunicorn config file. Default: []
+#
 # === Examples
 #
 # python::gunicorn { 'vhost':
@@ -83,6 +86,7 @@ define python::gunicorn (
   $errorlog          = false,
   $log_level          = 'error',
   $template          = 'python/gunicorn.erb',
+  $args              = [],
 ) {
 
   # Parameter validation

--- a/spec/defines/gunicorn_spec.rb
+++ b/spec/defines/gunicorn_spec.rb
@@ -26,6 +26,11 @@ describe 'python::gunicorn', :type => :define do
         let(:params) { { :dir => '/srv/testapp', :log_level => 'info' } }
         it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--log-level=info/) }
       end
+
+      context 'test-app with custom gunicorn preload arguments' do
+        let(:params) { { :dir => '/srv/testapp', :args  => ['--preload'] } }
+        it { is_expected.to contain_file('/etc/gunicorn.d/test-app').with_mode('0644').with_content(/--preload/) }
+      end
     end
   end
 end

--- a/templates/gunicorn.erb
+++ b/templates/gunicorn.erb
@@ -24,6 +24,11 @@ CONFIG = {
   'python': '/usr/bin/python',
 <% end -%>
   'args': (
+<% if @args.any? -%>
+<% for arg in @args do -%>
+    '<%= arg %>',
+<% end -%>
+<% end -%>
 <% if !@virtualenv and !@bind -%>
     '--bind=unix:/tmp/gunicorn-<%= @name %>.socket',
 <% elsif @virtualenv and !@bind -%>


### PR DESCRIPTION
This options allow to add custom arguments to the config without having to maintain a custom template.

