### PR TITLE
Minor puppet-lint related fixes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class python::install {
   $python = $::python::version ? {
     'system' => 'python',
     'pypy'   => 'pypy',
-    default  => "${python::version}",
+    default  => $python::version,
   }
 
   $pythondev = $::osfamily ? {
@@ -220,8 +220,8 @@ class python::install {
     }
 
     package { 'gunicorn':
-      name   => $python::gunicorn_package_name,
       ensure => $gunicorn_ensure,
+      name   => $python::gunicorn_package_name,
     }
   }
 }


### PR DESCRIPTION
In my use of this module, my CI system constantly complains about the two lines edited in this commit because they don't pass puppet-lint.  They are very minor, almost stylistic changes that I have made to the module internally (to appease the CI system) but it would be nice to not need to run a modified version of the module.