### PR TITLE
Remove puppet-lint ignore

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class python::install {
   $python = $::python::version ? {
     'system' => 'python',
     'pypy'   => 'pypy',
-    default  => "${python::version}", # lint:ignore:only_variable_string
+    default  => $python::version,
   }
 
   $pythondev = $::osfamily ? {


### PR DESCRIPTION
The puppet-lint ignore is unnecessary.  The behavior of this is absolutely identical to the previous behavior, just stylistically more correct.  Quoting the variable like this does not stringify it, it will still be parsed as an integer assuming that the value is all digits or a float if there is a single decimal.  The only way that the variable would evaluate to a string (under either the previous method, or this new method) would be if the value is both quoted AND there are either multiple decimals or other non-digit characters present (or using some hackery with sprintf).

If puppet needs to use the integer as a string (for example, embedding it within a second string) it will do the conversion automatically.  Ruby is a duck typed language after all ;)

Please review the following for verification of this:

Test 1:
```
root@testbox:~# cat test.pp 
$version=123
warning(type($version))
warning(type("${version}"))
```
```
root@testbox:~# puppet apply test.pp 
Warning: Scope(Class[main]): integer
Warning: Scope(Class[main]): integer
```

Test 2:
```
root@testbox:~# cat test.pp 
$version_int=123
$version_quoted = "${version_int}"
warning(type($version_int))
warning(type($version_quoted))
```
```
root@testbox:~# puppet apply test.pp 
Warning: Scope(Class[main]): integer
Warning: Scope(Class[main]): integer
```