### PR TITLE
Add support for Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.3.1
 
 env:
   matrix:
@@ -59,6 +60,24 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.5.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Puppet module for installing and managing python, pip, virtualenvs and Gunicorn 
 * 1.9.3
 * 2.0.0
 * 2.1.0
+* 2.3.1
 
 ## OS Distributions ##
 


### PR DESCRIPTION
Puppet is switching to use Ruby 2.3.1 for its agent in the next version.