### PR TITLE
RHSCL Repository installation made optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,8 +91,8 @@ class python (
   }
 
   $exec_prefix = $provider ? {
-    'scl'   => "scl enable ${version} -- ",
-    'rhscl' => "scl enable ${version} -- ",
+    'scl'   => "/usr/bin/scl enable ${version} -- ",
+    'rhscl' => "/usr/bin/scl enable ${version} -- ",
     default => '',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,7 @@ class python (
   $python_pyvenvs            = { },
   $python_requirements       = { },
   $use_epel                  = $python::params::use_epel,
+  $rhscl_use_public_repository = $python::params::rhscl_use_public_repository,
 ) inherits python::params{
 
   if $provider != undef and $provider != '' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,7 +50,7 @@ class python::install {
     name   => $python,
   }
 
-  package { 'virtualenv':
+  package { "virtualenv":
     ensure  => $venv_ensure,
     require => Package['python'],
   }
@@ -140,9 +140,14 @@ class python::install {
           provider => 'rpm',
           tag      => 'python-scl-repo',
         }
-        Package <| title == 'python' |> {
+      }
+
+      Package <| title == 'python' |> {
           tag => 'python-scl-package',
         }
+
+      Package <| title == 'virtualenv' |> {
+        name => "${python}-python-virtualenv",
       }
 
       package { "${python}-scldevel":
@@ -150,12 +155,9 @@ class python::install {
         tag    => 'python-scl-package',
       }
 
-      if $pip_ensure != 'absent' {
-        exec { 'python-scl-pip-install':
-          command => "${python::exec_prefix}easy_install pip",
-          path    => ['/usr/bin', '/bin'],
-          creates => "/opt/rh/${python::version}/root/usr/bin/pip",
-        }
+      package { "${python}-python-pip":
+        ensure => $pip_ensure,
+        tag    => 'python-pip-package',
       }
 
       if $::python::rhscl_use_public_repository {
@@ -164,7 +166,7 @@ class python::install {
       }
 
       Package <| tag == 'python-scl-package' |> ->
-      Exec['python-scl-pip-install']
+      Package <| tag == 'python-pip-package' |>
     }
     default: {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -133,15 +133,16 @@ class python::install {
     }
     rhscl: {
       # rhscl is RedHat SCLs from softwarecollections.org
-      $scl_package = "rhscl-${::python::version}-epel-${::operatingsystemmajrelease}-${::architecture}"
-      package { $scl_package:
-        source   => "https://www.softwarecollections.org/en/scls/rhscl/${::python::version}/epel-${::operatingsystemmajrelease}-${::architecture}/download/${scl_package}.noarch.rpm",
-        provider => 'rpm',
-        tag      => 'python-scl-repo',
-      }
-
-      Package <| title == 'python' |> {
-        tag => 'python-scl-package',
+      if $::python::rhscl_use_public_repository {
+        $scl_package = "rhscl-${::python::version}-epel-${::operatingsystemmajrelease}-${::architecture}"
+        package { $scl_package:
+          source   => "https://www.softwarecollections.org/en/scls/rhscl/${::python::version}/epel-${::operatingsystemmajrelease}-${::architecture}/download/${scl_package}.noarch.rpm",
+          provider => 'rpm',
+          tag      => 'python-scl-repo',
+        }
+        Package <| title == 'python' |> {
+          tag => 'python-scl-package',
+        }
       }
 
       package { "${python}-scldevel":
@@ -157,11 +158,14 @@ class python::install {
         }
       }
 
-      Package <| tag == 'python-scl-repo' |> ->
+      if $::python::rhscl_use_public_repository {
+        Package <| tag == 'python-scl-repo' |> ->
+        Package <| tag == 'python-scl-package' |>
+      }
+
       Package <| tag == 'python-scl-package' |> ->
       Exec['python-scl-pip-install']
     }
-
     default: {
 
       package { 'pip':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,7 +50,7 @@ class python::install {
     name   => $python,
   }
 
-  package { "virtualenv":
+  package { 'virtualenv':
     ensure  => $venv_ensure,
     require => Package['python'],
   }
@@ -143,8 +143,8 @@ class python::install {
       }
 
       Package <| title == 'python' |> {
-          tag => 'python-scl-package',
-        }
+        tag => 'python-scl-package',
+      }
 
       Package <| title == 'virtualenv' |> {
         name => "${python}-python-virtualenv",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,4 +23,6 @@ class python::params {
     default  => 'gunicorn',
   }
 
+  $rhscl_use_public_repository = true
+
 }

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -93,7 +93,7 @@ define python::virtualenv (
     $python = $version ? {
       'system' => 'python',
       'pypy'   => 'pypy',
-      default  => "${version}",
+      default  => "python${version}",
     }
 
     if $virtualenv == undef {

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -93,7 +93,7 @@ define python::virtualenv (
     $python = $version ? {
       'system' => 'python',
       'pypy'   => 'pypy',
-      default  => "python${version}",
+      default  => "${version}",
     }
 
     if $virtualenv == undef {


### PR DESCRIPTION
Hi,

this proposal contains the following changes to puppet-python:

1.)  add a switch to prevent the yum repository provisioning of SCL 
* the switch is useful if the repository is already configured independent of this module
* we use the puppet-python module in conjunction with our own repository module and therefore run in conflicts with the currently harcoded scl package install for yum repos (${scl_package}.noarch.rpm)

2.) fixed bug with puppet 3.8.7/--parser future by using a qualified path name for scl
Error: Validation of Exec[python_requirements_initial_install_...] failed: 'scl enable rh-python34 -- ...' is not qualified and no path was specified. Please qualify the command or specify a path. at /tmp/vagrant-puppet/.../python/manifests/virtualenv.pp:173

Please review my changes and give me feedback if you are willed to merge them, or if you would like to have changes on the current implementation.

Greetings,
Michael
