### PR TITLE
Do not try to reinstall packages installed via the OS

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -219,7 +219,7 @@ define python::pip (
         # Explicit version.
         exec { "pip_install_${name}":
           command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install ${install_args} \$wheel_support_flag ${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} || ${pip_env} --log ${log}/pip.log install ${install_args} ${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source}==${ensure} ;}",
-          unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          unless      => "${pip_env} freeze | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,
           cwd         => $cwd,
@@ -228,12 +228,12 @@ define python::pip (
           path        => $path,
         }
       }
-
+# 
       present: {
         # Whatever version is available.
         exec { "pip_install_${name}":
           command     => "${pip_env} wheel --help > /dev/null 2>&1 && { ${pip_env} wheel --version > /dev/null 2>&1 || wheel_support_flag='--no-use-wheel'; } ; { ${pip_env} --log ${log}/pip.log install \$wheel_support_flag ${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source} || ${pip_env} --log ${log}/pip.log install ${pypi_index} ${proxy_flag} ${install_args} ${install_editable} ${source} ;}",
-          unless      => "${pip_env} freeze | grep -i -e ${grep_regex}",
+          unless      => "${pip_env} freeze | grep -i -e ${grep_regex} || ${pip_env} list | sed -e 's/[ ]\+/==/' -e 's/[()]//g' | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,
           cwd         => $cwd,


### PR DESCRIPTION
Pip freeze provides another list than pip list, see
also online questions like:
   http://stackoverflow.com/questions/19837410/why-doesnt-setuptools-1-3-1-appear-when-i-pip-freeze

To prevent continuous reinstalls of things like setuptools,
examine pip list output as well.