### PR TITLE
Allow failure for Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--form
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - rvm: 2.3.1
   exclude:
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"


### PR DESCRIPTION
This is needed until the issue with the unit tests for the custom facts
is fixed.

https://github.com/stankevich/puppet-python/issues/336