### PR TITLE
Add name of package to pip uninstall command

### DIFF
--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -260,7 +260,7 @@ define python::pip (
       default: {
         # Anti-action, uninstall.
         exec { "pip_uninstall_${name}":
-          command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag}",
+          command     => "echo y | ${pip_env} uninstall ${uninstall_args} ${proxy_flag} ${name}",
           onlyif      => "${pip_env} freeze | grep -i -e ${grep_regex}",
           user        => $owner,
           group       => $group,


### PR DESCRIPTION
Without this fix, "ensure => absent" resulted in error:
'Error: echo y | pip uninstall   returned 1 instead of one of [0]'