### PR TITLE
Improve support for pip on CentOS7/EPEL

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -213,6 +213,9 @@ class python::install {
       if $::python::version =~ /^3/ {
         $pip_category = undef
         $pip_package = 'python3-pip'
+      } elsif ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemmajrelease, '7') >= 0) and ($python::use_epel == true) {
+        $pip_category = undef
+        $pip_package = 'python2-pip'
       } elsif $::osfamily == 'Gentoo' {
         $pip_category = 'dev-python'
         $pip_package = 'pip'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -213,7 +213,7 @@ class python::install {
       if $::python::version =~ /^3/ {
         $pip_category = undef
         $pip_package = 'python3-pip'
-      } elsif ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemmajrelease, '7') >= 0) and ($python::use_epel == true) {
+      } elsif ($::osfamily == 'RedHat') and (versioncmp($::operatingsystemmajrelease, '7') >= 0) {
         $pip_category = undef
         $pip_package = 'python2-pip'
       } elsif $::osfamily == 'Gentoo' {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -138,6 +138,7 @@ describe 'python', :type => :class do
     it { is_expected.to contain_package("python") }
     it { is_expected.to contain_package("python-dev").with_name("python-devel") }
     it { is_expected.to contain_package("pip") }
+    it { is_expected.to contain_package("pip").with_name('python-pip') }
     # Basic python packages (from pip)
     it { is_expected.to contain_package("virtualenv")}
 
@@ -215,6 +216,22 @@ describe 'python', :type => :class do
         it { is_expected.to contain_package("python-dev").with_ensure('absent') }
       end
     end
+  end
+
+  context "on a Redhat 6 OS" do
+    let :facts do
+      {
+        :id => 'root',
+        :kernel => 'Linux',
+        :osfamily => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :operatingsystemmajrelease => '6',
+        :concat_basedir => '/dne',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it { is_expected.to contain_class("python::install") }
+    it { is_expected.to contain_package("pip").with_name('python-pip') }
   end
 
   context "on a Redhat 7 OS" do

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -217,6 +217,22 @@ describe 'python', :type => :class do
     end
   end
 
+  context "on a Redhat 7 OS" do
+    let :facts do
+      {
+        :id => 'root',
+        :kernel => 'Linux',
+        :osfamily => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :operatingsystemmajrelease => '7',
+        :concat_basedir => '/dne',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it { is_expected.to contain_class("python::install") }
+    it { is_expected.to contain_package("pip").with_name('python2-pip') }
+  end
+
   context "on a SLES 11 SP3" do
     let :facts do
       {


### PR DESCRIPTION
Due to a recent change in EPEL the python-pip package was renamed to python2-pip. This currently breaks this module on CentOS 7. This commit makes sure that it defaults to python2-pip if the system is running Python 2 on CentOS 7 when using EPEL.