### PR TITLE
EL7 use python2-pip package name

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -216,6 +216,9 @@ class python::install {
       } elsif $::osfamily == 'Gentoo' {
         $pip_category = 'dev-python'
         $pip_package = 'pip'
+      } elsif ($::osfamily == 'RedHat') and ($::operatingsystemrelease =~ /^7/) {
+        $pip_category = undef
+        $pip_package = 'python2-pip'
       } else {
         $pip_category = undef
         $pip_package = 'python-pip'


### PR DESCRIPTION
It turns out that the package name has changed in the epel repository.
closes #348

Signed-off-by: David Caro <david@dcaro.es>