### PR TITLE
quick fix for failing travis builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ env:
     - PUPPET_GEM_VERSION="~> 4.8.0"
     - PUPPET_GEM_VERSION="~> 4.9.0"
     - PUPPET_GEM_VERSION="~> 4.10.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,8 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.8.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.3.1
@@ -98,6 +100,11 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.8.0"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    # deprecated ruby versions in puppet 4.9.0
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4.9.0" 
     # deprecated ruby versions in puppet 4.10.0
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 4.10.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ env:
     - PUPPET_GEM_VERSION="~> 4.6.0"
     - PUPPET_GEM_VERSION="~> 4.7.0"
     - PUPPET_GEM_VERSION="~> 4.8.0"
-    - PUPPET_GEM_VERSION="~> 4"
+    - PUPPET_GEM_VERSION="~> 4.9.0"
+    - PUPPET_GEM_VERSION="~> 4.10.0"
 
 sudo: false
 
@@ -76,7 +77,7 @@ matrix:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.8.0"
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
+      env: PUPPET_GEM_VERSION="~> 4.9.0"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.3.1
@@ -95,6 +96,11 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.8.0"
     - rvm: 2.3.1
       env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    # deprecated ruby versions in puppet 4.10.0
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 4.10.0"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ else
   gem 'facter', :require => false
 end
 
-gem 'puppetlabs_spec_helper', '>= 1.2.0', :require => false
+gem 'puppetlabs_spec_helper', '>= 1.2.0', '<= 1.2.2', :require => false
 gem 'rspec-puppet', :require => false
 gem 'puppet-lint', '~> 2.0', :require => false
 gem 'simplecov', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,9 @@ else
   gem 'facter', :require => false
 end
 
-gem 'puppetlabs_spec_helper', '>= 1.2.0', '<= 1.2.2', :require => false
+gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
+
 gem 'rspec-puppet', :require => false
 gem 'puppet-lint', '~> 2.0', :require => false
 gem 'simplecov', :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,10 +133,10 @@ class python (
   }
 
   # Anchor pattern to contain dependencies
-  anchor { 'python::begin': } ->
-  class { 'python::install': } ->
-  class { 'python::config': } ->
-  anchor { 'python::end': }
+  anchor { 'python::begin': }
+  -> class { 'python::install': }
+  -> class { 'python::config': }
+  -> anchor { 'python::end': }
 
   # Allow hiera configuration of python resources
   create_resources('python::pip', $python_pips)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -164,12 +164,12 @@ class python::install {
       }
 
       if $::python::rhscl_use_public_repository {
-        Package <| tag == 'python-scl-repo' |> ->
-        Package <| tag == 'python-scl-package' |>
+        Package <| tag == 'python-scl-repo' |>
+        -> Package <| tag == 'python-scl-package' |>
       }
 
-      Package <| tag == 'python-scl-package' |> ->
-      Package <| tag == 'python-pip-package' |>
+      Package <| tag == 'python-scl-package' |>
+      -> Package <| tag == 'python-pip-package' |>
     }
     default: {
 


### PR DESCRIPTION
This does two things:

1. pegs puppetlabs_spec_helper gem to v1.2.2 b/c this module is not compatible w/ 2.*.*
2. fixes arrow warnings thrown by newer puppet-lint gem.

Although the better fix re (1) might be to switch over to using the newer spec_helper, at least this will allow tests to pass in the meantime.

Closes #372 .