### PR TITLE
Making sure, if you define a python binary, use it.

### DIFF
--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -93,6 +93,7 @@ define python::virtualenv (
     $python = $version ? {
       'system' => 'python',
       'pypy'   => 'pypy',
+      /python/ => $version,
       default  => "python${version}",
     }
 


### PR DESCRIPTION
When you define a binary, use it.