### PR TITLE
Fix tests: Pin rake for ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'simplecov', :require => false
 
 gem 'rspec',     '~> 2.0', :require => false          if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'rake',      '~> 10.0', :require => false         if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rake',      '<= 12.2.1', :require => false       if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0.0'
 gem 'json',      '<= 1.8', :require => false          if RUBY_VERSION < '2.0.0'
 gem 'json_pure', '<= 2.0.1', :require => false        if RUBY_VERSION < '2.0.0'
 gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'


### PR DESCRIPTION
Rake >12.2.1 throws the following error:

 rake-12.3.1 requires ruby version >= 2.0.0, which is incompatible with
 the current version, ruby 1.9.3p551