### PR TITLE
add pip support for setuptools extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Installs and manages packages from pip.
 
 **environment** - Additional environment variables required to install the packages. Default: none
 
+**extras** - Extra features provided by the package which should be installed. Default: none
+
 **egg** - The egg name to use. Default: `$name` of the class, e.g. cx_Oracle
 
 **install_args** - String of additional flags to pass to pip during installaton. Default: none
@@ -316,7 +318,7 @@ python::python_dotfiles:
 ### Using SCL packages from RedHat or CentOS
 
 To use this module with Linux distributions in the Red Hat family and python distributions
-from softwarecollections.org, set python::provider to 'rhscl' and python::version to the name 
+from softwarecollections.org, set python::provider to 'rhscl' and python::version to the name
 of the collection you want to use (e.g., 'python27', 'python33', or 'rh-python34').
 
 ## Release Notes

--- a/manifests/pip.pp
+++ b/manifests/pip.pp
@@ -37,6 +37,9 @@
 # [*environment*]
 #  Additional environment variables required to install the packages. Default: none
 #
+# [*extras*]
+#  Extra features provided by the package which should be installed. Default: none
+#
 # [*timeout*]
 #  The maximum time in seconds the "pip install" command should take. Default: 1800
 #
@@ -76,6 +79,7 @@ define python::pip (
   $egg             = false,
   $editable        = false,
   $environment     = [],
+  $extras          = [],
   $install_args    = '',
   $uninstall_args  = '',
   $timeout         = 1800,
@@ -161,13 +165,18 @@ define python::pip (
     }
   }
 
+  $extras_string = empty($extras) ? {
+    true    => '',
+    default => sprintf('[%s]',join($extras,',')),
+  }
+
   $egg_name = $egg ? {
-    false   => $pkgname,
+    false   => "${pkgname}${extras_string}",
     default => $egg
   }
 
   $source = $url ? {
-    false               => $pkgname,
+    false               => "${pkgname}${extras_string}",
     /^(\/|[a-zA-Z]\:)/  => $url,
     /^(git\+|hg\+|bzr\+|svn\+)(http|https|ssh|svn|sftp|ftp|lp)(:\/\/).+$/ => $url,
     default             => "${url}#egg=${egg_name}",

--- a/spec/defines/pip_spec.rb
+++ b/spec/defines/pip_spec.rb
@@ -69,3 +69,32 @@ describe 'python::pip', :type => :define do
 
   end
 end
+
+describe 'python::pip', :type => :define do
+  let (:title) { 'requests' }
+  context "on Debian OS" do
+    let :facts do
+      {
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :lsbdistcodename        => 'squeeze',
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
+        :operatingsystemrelease => '6',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    describe "extras as" do
+      context "suceeds with no extras" do
+        let (:params) {{ }}
+        it { is_expected.to contain_exec("pip_install_requests").with_command("pip wheel --help > /dev/null 2>&1 && { pip show wheel > /dev/null 2>&1 || wheel_support_flag='--no-binary :all:'; } ; { pip --log /tmp/pip.log install $wheel_support_flag     requests || pip --log /tmp/pip.log install     requests ;}") }
+      end
+      context "succeeds with extras" do
+        let (:params) {{ :extras => ['security'] }}
+        it { is_expected.to contain_exec("pip_install_requests").with_command("pip wheel --help > /dev/null 2>&1 && { pip show wheel > /dev/null 2>&1 || wheel_support_flag='--no-binary :all:'; } ; { pip --log /tmp/pip.log install $wheel_support_flag     requests[security] || pip --log /tmp/pip.log install     requests[security] ;}") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for installing setuptools extras (https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras).

I believe this change can resolve https://github.com/stankevich/puppet-python/issues/284 and https://github.com/stankevich/puppet-python/issues/218 by changing the declaration from 
```
python::pip { 'somePackage[extra]': }
```
to
```
python::pip { 'somePackage': 
  extras => [extra],
}
```