### PR TITLE
`init.pp`: remove useless `exec` with `default` title that was trying to set a default `umask`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -180,11 +180,7 @@ Default value: `true`
 
 ##### <a name="-python--umask"></a>`umask`
 
-Data type: `Optional[Python::Umask]`
-
 The default umask for invoked exec calls.
-
-Default value: `undef`
 
 ##### <a name="-python--manage_gunicorn"></a>`manage_gunicorn`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,6 @@ class python (
   Stdlib::Httpurl            $anaconda_installer_url      = 'https://repo.anaconda.com/archive/Anaconda3-5.2.0-Linux-x86_64.sh',
   Stdlib::Absolutepath       $anaconda_install_path       = '/opt/python',
   Boolean                    $manage_scl                  = true,
-  Optional[Python::Umask]    $umask                       = undef,
 ) inherits python::params {
   $exec_prefix = $provider ? {
     'scl'   => "/usr/bin/scl enable ${version} -- ",
@@ -75,11 +74,6 @@ class python (
 
   Class['python::install']
   -> Class['python::config']
-
-  # Set default umask.
-  exec { default:
-    umask => $umask,
-  }
 
   # Allow hiera configuration of python resources
   create_resources('python::pip', $python_pips)


### PR DESCRIPTION
Per the docs, the special value `default` sets default attribute values for other resource bodies in the same expression. There are no resources in this expression so it doesn't do anything. This was probably intended to be a "legacy-style default", but the style guide says to avoid these anyway.

Docs references:

* https://help.puppet.com/core/8/Content/PuppetCore/style_guide_resources.htm
* https://help.puppet.com/core/8/Content/PuppetCore/lang_resource_syntax.htm